### PR TITLE
add provider package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -95,6 +95,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -109,6 +116,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.5+1"
   quiver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 
   cupertino_icons: 0.1.3
 
+  provider: 4.0.5+1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
https://flutter.dev/docs/development/data-and-backend/state-mgmt/simple この方針で実装するので、provider package を追加しやす。