### PR TITLE
add comment for analysis_options exclude option

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,8 @@ analyzer:
     implicit-casts: false
     implicit-dynamic: false
 
-  # ref: https://github.com/dart-lang/sdk/issues/25551
+  # See: https://github.com/dart-lang/sdk/issues/25551#issuecomment-608501698
+  # See: https://github.com/dart-lang/sdk/issues/34098
   exclude:
     - lib/i18n/**
 
@@ -21,7 +22,7 @@ linter:
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
     - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks  # under review (see https://github.com/dart-lang/linter/issues/1068)
+    - avoid_double_and_int_checks # under review (see https://github.com/dart-lang/linter/issues/1068)
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes # under review (see https://github.com/dart-lang/linter/issues/1068)
     - avoid_function_literals_in_foreach_calls


### PR DESCRIPTION
See: https://github.com/dart-lang/sdk/issues/25551#issuecomment-608501698
See: https://github.com/dart-lang/sdk/issues/34098

要は生成されたコードの exclude 今できんよ！ Dart 2.9 を待ってな！ って話。