### PR TITLE
auto Assignee on PR

### DIFF
--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,0 +1,3 @@
+addReviewers: false
+
+addAssignees: author # See: https://github.com/marketplace/actions/auto-assign-action#assign-author-as-assignee

--- a/.github/workflows/pr_auto_assign.yaml
+++ b/.github/workflows/pr_auto_assign.yaml
@@ -1,0 +1,14 @@
+name: PR_Auto_Assign
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-assignees:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/auto_assign.yaml"


### PR DESCRIPTION
## 概要
PR の Assinees に、PR 作者を自動で入れるようにする。

なお、Reviewer は自動で入れない。
**CI 全部通ったのを確認した上で、PR 作者自信が内容吟味してReview していい状態になったと思ってからレビュアーを指定すべき** だと思うので。

## 参考
* https://github.com/marketplace/actions/auto-assign-action : 今回使った GitHub Action