### PR TITLE
fix pubspec description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 # See: https://dart.dev/tools/pub/pubspec
 
 name: HumanLifeGame
-description: HumanLife Game Generator
+description: HumanLife Game
 
 publish_to: "none"
 


### PR DESCRIPTION
## 概要

昔の名残で Generator という単語が表面に出てたので直した

