### PR TITLE
Router

### DIFF
--- a/lib/human_life_game_app.dart
+++ b/lib/human_life_game_app.dart
@@ -1,26 +1,35 @@
-import 'package:HumanLifeGame/screens/play_room/play_room.dart';
+import 'package:HumanLifeGame/router.dart';
 import 'package:HumanLifeGame/i18n/i18n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
 
 import 'i18n/i18n_delegate.dart';
 
 class HumanLifeGameApp extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => MaterialApp(
-        onGenerateTitle: (context) => I18n.of(context).appTitle,
-        localizationsDelegates: const [
-          I18nDelegate(),
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
+  Widget build(BuildContext context) => MultiProvider(
+        providers: [
+          Provider(create: (context) => Router()),
         ],
-        supportedLocales: const [Locale('en', 'US'), Locale('ja', 'JP')],
-        locale: const Locale('en'),
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-          visualDensity: VisualDensity.adaptivePlatformDensity,
+        child: Consumer<Router>(
+          builder: (_, router, __) => MaterialApp(
+            onGenerateTitle: (context) => I18n.of(context).appTitle,
+            localizationsDelegates: const [
+              I18nDelegate(),
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [Locale('en', 'US'), Locale('ja', 'JP')],
+            locale: const Locale('en'),
+            theme: ThemeData(
+              primarySwatch: Colors.blue,
+              visualDensity: VisualDensity.adaptivePlatformDensity,
+            ),
+            initialRoute: router.initialRoute,
+            routes: router.routes,
+          ),
         ),
-        home: PlayRoom(),
       );
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,0 +1,10 @@
+import 'package:HumanLifeGame/screens/play_room/play_room.dart';
+import 'package:flutter/material.dart';
+
+class Router {
+  final String initialRoute = '/';
+
+  final Map<String, WidgetBuilder> routes = {
+    '/': (context) => PlayRoom(),
+  };
+}


### PR DESCRIPTION
## 概要

画面のルーティング実装の基盤部分を追加。
画面遷移時に各所で `'/login'` みたいなハードコーディングがされるのを避けるために、頭で Router クラスを挿し込んでおきます。

これで、こんな風に書けるようになる。
```dart
final router = Provider.of<Router>(context)
Navigator.of(context).pushNamed(router.login);
```

## 特に見て欲しいところ

特になし

## 参考リンク

* **https://flutter.dev/docs/cookbook/navigation/named-routes**
