### PR TITLE
separate i18n file

### DIFF
--- a/lib/i18n/extensions/i18n_common.dart
+++ b/lib/i18n/extensions/i18n_common.dart
@@ -1,0 +1,11 @@
+import 'package:HumanLifeGame/i18n/i18n.dart';
+import 'package:intl/intl.dart';
+
+/// Common Locale Text
+extension Common on I18n {
+  String get appTitle => Intl.message(
+        'Human Life Game',
+        name: 'appTitle',
+        locale: localeName,
+      );
+}

--- a/lib/i18n/extensions/i18n_play_room.dart
+++ b/lib/i18n/extensions/i18n_play_room.dart
@@ -1,0 +1,11 @@
+import 'package:HumanLifeGame/i18n/i18n.dart';
+import 'package:intl/intl.dart';
+
+/// PlayRoom Locale Text
+extension PlayRoom on I18n {
+  String get rollDice => Intl.message(
+        'roll the dice',
+        name: 'rollDice',
+        locale: localeName,
+      );
+}

--- a/lib/i18n/extensions/i18n_play_room.dart
+++ b/lib/i18n/extensions/i18n_play_room.dart
@@ -4,7 +4,7 @@ import 'package:intl/intl.dart';
 /// PlayRoom Locale Text
 extension PlayRoom on I18n {
   String get rollDice => Intl.message(
-        'roll the dice',
+        'Roll the dice',
         name: 'rollDice',
         locale: localeName,
       );

--- a/lib/i18n/i18n.dart
+++ b/lib/i18n/i18n.dart
@@ -2,6 +2,9 @@ import 'package:HumanLifeGame/i18n/messages_all.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+export 'extensions/i18n_common.dart';
+export 'extensions/i18n_play_room.dart';
+
 class I18n {
   I18n(this.localeName);
 
@@ -15,17 +18,4 @@ class I18n {
   static I18n of(BuildContext context) => Localizations.of<I18n>(context, I18n);
 
   final String localeName;
-
-  String get appTitle => Intl.message(
-        'Human Life Game',
-        name: 'appTitle',
-        locale: localeName,
-      );
-
-  String get start => Intl.message(
-        'Start',
-        name: 'start',
-        desc: 'Text for start button.',
-        locale: localeName,
-      );
 }

--- a/lib/screens/play_room/player_action.dart
+++ b/lib/screens/play_room/player_action.dart
@@ -12,7 +12,7 @@ class PlayerAction extends StatelessWidget {
             textColor: Colors.white,
             onPressed: () {},
             child: Text(
-              I18n.of(context).start,
+              I18n.of(context).rollDice,
               style: const TextStyle(fontSize: 20),
             ),
           ),

--- a/test/widget/player_action_test.dart
+++ b/test/widget/player_action_test.dart
@@ -8,7 +8,7 @@ void main() {
     testWidgets("show 'start' text", (tester) async {
       await tester.pumpWidget(_PlayerAction());
       await tester.pump();
-      expect(find.text('Start'), findsOneWidget);
+      expect(find.text('Roll the dice'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## 概要

`i18n.dart` に書き連ねていくと、`i18n.dart` がとても長いファイルになる & どの key が何に使われてるかがよくわからなくなる という辛さがある。

なので、せめてファイル別に書けるようにします。

ただし、各 extension で key が衝突しないように気をつけなきゃいけないのは今まで通り。
そこまでテキスト数多くならないと思うし、多分そこまでしなくていいかなと。

## 特に見て欲しいところ

* Dart 2.7 から入った [Extension methods](https://dart.dev/guides/language/extension-methods) を使ってる
* `/i18n/extensions` とかいう雑な命名のディレクトリ...
