### PR TITLE
add play action model

### DIFF
--- a/lib/models/player_action.dart
+++ b/lib/models/player_action.dart
@@ -9,9 +9,8 @@ class PlayerActionModel extends ChangeNotifier {
 
   int get dice => _dice;
 
-  Random rand = Random();
-
   void rollDice() {
+    final rand = Random();
     _dice = rand.nextInt(maxDiceNumber) + 1;
     notifyListeners();
   }

--- a/lib/models/player_action.dart
+++ b/lib/models/player_action.dart
@@ -1,0 +1,13 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+class PlayerActionModel extends ChangeNotifier {
+  int _dice = 0;
+  int get dice => _dice;
+  Random rand = Random();
+  void rollDice() {
+    _dice = rand.nextInt(6) + 1;
+    notifyListeners();
+  }
+}

--- a/lib/models/player_action.dart
+++ b/lib/models/player_action.dart
@@ -1,15 +1,18 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 class PlayerActionModel extends ChangeNotifier {
-  final int _maxDiceNumber = 6;
+  @visibleForTesting
+  final int maxDiceNumber = 6;
   int _dice = 0;
+
   int get dice => _dice;
 
   Random rand = Random();
+
   void rollDice() {
-    _dice = rand.nextInt(_maxDiceNumber) + 1;
+    _dice = rand.nextInt(maxDiceNumber) + 1;
     notifyListeners();
   }
 }

--- a/lib/models/player_action.dart
+++ b/lib/models/player_action.dart
@@ -3,11 +3,13 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 class PlayerActionModel extends ChangeNotifier {
+  final int _maxDiceNumber = 6;
   int _dice = 0;
   int get dice => _dice;
+
   Random rand = Random();
   void rollDice() {
-    _dice = rand.nextInt(6) + 1;
+    _dice = rand.nextInt(_maxDiceNumber) + 1;
     notifyListeners();
   }
 }

--- a/lib/screens/play_room/dice_result.dart
+++ b/lib/screens/play_room/dice_result.dart
@@ -9,9 +9,9 @@ class DiceResult extends StatelessWidget {
         width: 100,
         height: 100,
         child: Consumer<PlayerActionModel>(
-          builder: (context, playerAction, child) => Text(
-            '${playerAction.dice.toString()}',
-            key: const Key('dice-result-text'),
+          builder: (context, model, child) => Text(
+            '${model.dice.toString()}',
+            key: const Key('diceResultText'),
           ),
         ),
       );

--- a/lib/screens/play_room/dice_result.dart
+++ b/lib/screens/play_room/dice_result.dart
@@ -1,11 +1,18 @@
+import 'package:HumanLifeGame/models/player_action.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 /// ダイスを降った結果
 class DiceResult extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => const SizedBox(
+  Widget build(BuildContext context) => SizedBox(
         width: 100,
         height: 100,
-        child: Text('2'),
+        child: Consumer<PlayerActionModel>(
+          builder: (context, playerAction, child) => Text(
+            '${playerAction.dice.toString()}',
+            key: const Key('dice-result-text'),
+          ),
+        ),
       );
 }

--- a/lib/screens/play_room/play_room.dart
+++ b/lib/screens/play_room/play_room.dart
@@ -1,17 +1,22 @@
+import 'package:HumanLifeGame/models/player_action.dart';
 import 'package:HumanLifeGame/screens/play_room/human_life_stages.dart';
 import 'package:HumanLifeGame/screens/play_room/dice_result.dart';
 import 'package:HumanLifeGame/screens/play_room/player_action.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class PlayRoom extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
-        body: Column(
-          children: <Widget>[
-            HumanLifeStages(),
-            DiceResult(),
-            PlayerAction(),
-          ],
+        body: ChangeNotifierProvider(
+          create: (context) => PlayerActionModel(),
+          child: Column(
+            children: <Widget>[
+              HumanLifeStages(),
+              DiceResult(),
+              PlayerAction(),
+            ],
+          ),
         ),
       );
 }

--- a/lib/screens/play_room/player_action.dart
+++ b/lib/screens/play_room/player_action.dart
@@ -10,6 +10,7 @@ class PlayerAction extends StatelessWidget {
           width: 100,
           height: 100,
           child: FlatButton(
+            key: const Key('player-action-dice-roll-button'),
             color: Colors.blue,
             textColor: Colors.white,
             onPressed: () {

--- a/lib/screens/play_room/player_action.dart
+++ b/lib/screens/play_room/player_action.dart
@@ -10,7 +10,7 @@ class PlayerAction extends StatelessWidget {
           width: 100,
           height: 100,
           child: FlatButton(
-            key: const Key('player-action-dice-roll-button'),
+            key: const Key('playerActionDiceRollButton'),
             color: Colors.blue,
             textColor: Colors.white,
             onPressed: () {

--- a/lib/screens/play_room/player_action.dart
+++ b/lib/screens/play_room/player_action.dart
@@ -1,5 +1,7 @@
 import 'package:HumanLifeGame/i18n/i18n.dart';
+import 'package:HumanLifeGame/models/player_action.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class PlayerAction extends StatelessWidget {
   @override
@@ -10,7 +12,9 @@ class PlayerAction extends StatelessWidget {
           child: FlatButton(
             color: Colors.blue,
             textColor: Colors.white,
-            onPressed: () {},
+            onPressed: () {
+              Provider.of<PlayerActionModel>(context, listen: false).rollDice();
+            },
             child: Text(
               I18n.of(context).start,
               style: const TextStyle(fontSize: 20),

--- a/test/unit/player_action_model_test.dart
+++ b/test/unit/player_action_model_test.dart
@@ -4,9 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('PlayerActionModel', () {
     test("Dice value shuld be '1 <= value <= 6')", () {
-      final playerActionModel = PlayerActionModel()..rollDice();
+      final model = PlayerActionModel()..rollDice();
 
-      expect(playerActionModel.dice, inInclusiveRange(1, 6));
+      expect(model.dice, inInclusiveRange(1, 6));
     });
   });
 }

--- a/test/unit/player_action_model_test.dart
+++ b/test/unit/player_action_model_test.dart
@@ -6,7 +6,7 @@ void main() {
     test("Dice value shuld be '1 <= value <= 6')", () {
       final model = PlayerActionModel()..rollDice();
 
-      expect(model.dice, inInclusiveRange(1, 6));
+      expect(model.dice, inInclusiveRange(1, model.maxDiceNumber));
     });
   });
 }

--- a/test/unit/player_action_model_test.dart
+++ b/test/unit/player_action_model_test.dart
@@ -1,0 +1,12 @@
+import 'package:HumanLifeGame/models/player_action.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlayerActionModel', () {
+    test("Dice value shuld be '1 <= value <= 6')", () {
+      final playerActionModel = PlayerActionModel()..rollDice();
+
+      expect(playerActionModel.dice, inInclusiveRange(1, 6));
+    });
+  });
+}

--- a/test/widget/dice_result_test.dart
+++ b/test/widget/dice_result_test.dart
@@ -1,29 +1,5 @@
-import 'package:HumanLifeGame/screens/play_room/dice_result.dart';
-import 'package:HumanLifeGame/i18n/i18n_delegate.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('DiceResult', () {
-    testWidgets("show '2' text", (tester) async {
-      await tester.pumpWidget(_DiceResult());
-      await tester.pump();
-      expect(find.text('2'), findsOneWidget);
-    });
-  });
-}
-
-class _DiceResult extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) => MaterialApp(
-        title: 'Test App For DiceResult',
-        localizationsDelegates: const [I18nDelegate()],
-        supportedLocales: const [Locale('en', 'US')],
-        locale: const Locale('en'),
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-          visualDensity: VisualDensity.adaptivePlatformDensity,
-        ),
-        home: DiceResult(),
-      );
+  group('DiceResult', () {});
 }

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -17,14 +17,14 @@ void main() {
     });
     testWidgets('random value(1 <= value <= 6) should be displayed in disc_result when start button is tapped',
         (tester) async {
-      const testKey = Key('dice-result-text');
-
+      const diceResultText = Key('dice-result-text');
+      const rollDiceButton = Key('player-action-dice-roll-button');
       await tester.pumpWidget(_PlayRoom());
       await tester.pump();
 
-      await tester.tap(find.text('Start'));
+      await tester.tap(find.byKey(rollDiceButton));
       await tester.pump();
-      final text = find.byKey(testKey).evaluate().first.widget as Text;
+      final text = find.byKey(diceResultText).evaluate().first.widget as Text;
       expect(num.parse(text.data), inInclusiveRange(1, 6));
     });
   });

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -15,6 +15,17 @@ void main() {
       expect(find.byType(DiceResult), findsOneWidget);
       expect(find.byType(HumanLifeStages), findsOneWidget);
     });
+    testWidgets('', (tester) async {
+      const testKey = Key('dice-result-text');
+
+      await tester.pumpWidget(_PlayRoom());
+      await tester.pump();
+
+      await tester.tap(find.text('Start'));
+      await tester.pump();
+      final text = find.byKey(testKey).evaluate().first.widget as Text;
+      expect(num.parse(text.data), inInclusiveRange(1, 6));
+    });
   });
 }
 

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -15,8 +15,7 @@ void main() {
       expect(find.byType(DiceResult), findsOneWidget);
       expect(find.byType(HumanLifeStages), findsOneWidget);
     });
-    testWidgets('random value(1 <= value <= 6) shuld be displayed in dice_result when start button is tapped',
-        (tester) async {
+    testWidgets("show 'dice-result-text' Text when start button is tapped", (tester) async {
       const testKey = Key('dice-result-text');
 
       await tester.pumpWidget(_PlayRoom());
@@ -24,8 +23,8 @@ void main() {
 
       await tester.tap(find.text('Start'));
       await tester.pump();
-      final text = find.byKey(testKey).evaluate().first.widget as Text;
-      expect(num.parse(text.data), inInclusiveRange(1, 6));
+
+      expect(find.byKey(testKey), findsOneWidget);
     });
   });
 }

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -15,7 +15,8 @@ void main() {
       expect(find.byType(DiceResult), findsOneWidget);
       expect(find.byType(HumanLifeStages), findsOneWidget);
     });
-    testWidgets('', (tester) async {
+    testWidgets('random value(1 <= value <= 6) shuld be displayed in dice_result when start button is tapped',
+        (tester) async {
       const testKey = Key('dice-result-text');
 
       await tester.pumpWidget(_PlayRoom());

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -15,7 +15,8 @@ void main() {
       expect(find.byType(DiceResult), findsOneWidget);
       expect(find.byType(HumanLifeStages), findsOneWidget);
     });
-    testWidgets("show 'dice-result-text' Text when start button is tapped", (tester) async {
+    testWidgets('random value(1 <= value <= 6) should be displayed in disc_result when start button is tapped',
+        (tester) async {
       const testKey = Key('dice-result-text');
 
       await tester.pumpWidget(_PlayRoom());
@@ -23,8 +24,8 @@ void main() {
 
       await tester.tap(find.text('Start'));
       await tester.pump();
-
-      expect(find.byKey(testKey), findsOneWidget);
+      final text = find.byKey(testKey).evaluate().first.widget as Text;
+      expect(num.parse(text.data), inInclusiveRange(1, 6));
     });
   });
 }

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -1,3 +1,4 @@
+import 'package:HumanLifeGame/models/player_action.dart';
 import 'package:HumanLifeGame/screens/play_room/dice_result.dart';
 import 'package:HumanLifeGame/screens/play_room/human_life_stages.dart';
 import 'package:HumanLifeGame/screens/play_room/play_room.dart';
@@ -25,7 +26,8 @@ void main() {
       await tester.tap(find.byKey(rollDiceButton));
       await tester.pump();
       final text = find.byKey(diceResultText).evaluate().first.widget as Text;
-      expect(num.parse(text.data), inInclusiveRange(1, 6));
+      final model = PlayerActionModel();
+      expect(num.parse(text.data), inInclusiveRange(1, model.maxDiceNumber));
     });
   });
 }

--- a/test/widget/play_room_test.dart
+++ b/test/widget/play_room_test.dart
@@ -17,8 +17,8 @@ void main() {
     });
     testWidgets('random value(1 <= value <= 6) should be displayed in disc_result when start button is tapped',
         (tester) async {
-      const diceResultText = Key('dice-result-text');
-      const rollDiceButton = Key('player-action-dice-roll-button');
+      const diceResultText = Key('diceResultText');
+      const rollDiceButton = Key('playerActionDiceRollButton');
       await tester.pumpWidget(_PlayRoom());
       await tester.pump();
 


### PR DESCRIPTION
## 概要

サイコロの状態を保持するため、PlayerActionのモデルを追加

## 特に見て欲しいところ

play_room_testのテストが問題ないか

## 参考リンク

* https://flutter.dev/docs/cookbook/testing/widget/finders#2-find-a-widget-with-a-specific-key
