### PR TITLE
Provide PlayerActionModel 

### DIFF
--- a/lib/models/human_life.dart
+++ b/lib/models/human_life.dart
@@ -1,7 +1,7 @@
 import 'package:HumanLifeGame/models/life_road.dart';
 import 'package:HumanLifeGame/models/user.dart';
 
-class HumanLife {
+class HumanLifeModel {
   String title;
   UserModel author;
   LifeRoad lifeRoad;

--- a/lib/models/life_road.dart
+++ b/lib/models/life_road.dart
@@ -1,13 +1,7 @@
 import 'package:HumanLifeGame/models/life_step.dart';
 
 class LifeRoad {
-  // 二次元配列で表現された LifeStep
-  // LifeStep を二次元配列的に配置,表現するのに使う
-  List<List<LifeStepModel>> lifeStepsOnBoard;
+  LifeRoad(this.lifeStepsOnBoard);
 
-  // TODO: 実装
-  // リスト構造で表現された Step の情報を持つ。
-  // 「進行方向」を知るのに使う。
-  // LifeSteoModel start;
-  // LifeStepModel goal;
+  final List<List<LifeStepModel>> lifeStepsOnBoard;
 }

--- a/lib/models/life_step.dart
+++ b/lib/models/life_step.dart
@@ -1,7 +1,24 @@
 import 'package:HumanLifeGame/models/life_event.dart';
+import 'package:flutter/foundation.dart';
 
 class LifeStepModel {
-  LifeStepModel(this.lifeEvent);
+  LifeStepModel(
+    this.lifeEvent,
+    this.right,
+    this.left,
+    this.up,
+    this.down, {
+    @required this.isStart,
+    @required this.isGoal,
+  });
 
   final LifeEventModel lifeEvent;
+
+  final bool isStart;
+  final bool isGoal;
+
+  final LifeStepModel up;
+  final LifeStepModel down;
+  final LifeStepModel right;
+  final LifeStepModel left;
 }

--- a/lib/models/play_room.dart
+++ b/lib/models/play_room.dart
@@ -1,14 +1,37 @@
 import 'package:HumanLifeGame/models/announcement.dart';
 import 'package:HumanLifeGame/models/human.dart';
+import 'package:HumanLifeGame/models/human_life.dart';
 import 'package:HumanLifeGame/models/life_event.dart';
+import 'package:HumanLifeGame/models/player_action.dart';
 import 'package:HumanLifeGame/screens/play_room/human_life_stages.dart';
 import 'package:flutter/foundation.dart';
 
-class PlayRoom extends ChangeNotifier {
-  String title;
+class PlayRoomModel extends ChangeNotifier {
+  PlayerActionModel _playerAction;
+
+  PlayerActionModel get playerAction => _playerAction;
+
+  set playerAction(PlayerActionModel playerAction) {
+    _playerAction = playerAction;
+    notifyListeners();
+  }
+
+  String roomTitle;
+
+  // 参加する人
   List<HumanModel> humans;
+
+  // 歩む対象となる人生
+  HumanLifeModel humanLife;
+
+  // 参加者のそれぞれの人生の進捗
   List<HumanLifeStages> humanLifeStages;
+
+  // 手番の人
   HumanModel currentPlayer;
-  List<LifeEventModel> everyLifeEventRecords; // all human LifeEventRecord
+
+  // 全参加者の LifeEvent 履歴
+  List<LifeEventModel> everyLifeEventRecords;
+
   AnnouncementModel announcement;
 }

--- a/lib/screens/play_room/dice_result.dart
+++ b/lib/screens/play_room/dice_result.dart
@@ -8,11 +8,9 @@ class DiceResult extends StatelessWidget {
   Widget build(BuildContext context) => SizedBox(
         width: 100,
         height: 100,
-        child: Consumer<PlayerActionModel>(
-          builder: (context, model, child) => Text(
-            '${model.dice.toString()}',
-            key: const Key('diceResultText'),
-          ),
+        child: Text(
+          Provider.of<PlayerActionModel>(context).dice.toString(),
+          key: const Key('diceResultText'),
         ),
       );
 }

--- a/lib/screens/play_room/play_room.dart
+++ b/lib/screens/play_room/play_room.dart
@@ -1,3 +1,4 @@
+import 'package:HumanLifeGame/models/play_room.dart';
 import 'package:HumanLifeGame/models/player_action.dart';
 import 'package:HumanLifeGame/screens/play_room/human_life_stages.dart';
 import 'package:HumanLifeGame/screens/play_room/dice_result.dart';
@@ -8,8 +9,14 @@ import 'package:provider/provider.dart';
 class PlayRoom extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
-        body: ChangeNotifierProvider(
-          create: (context) => PlayerActionModel(),
+        body: MultiProvider(
+          providers: [
+            ChangeNotifierProvider(create: (context) => PlayerActionModel()),
+            ChangeNotifierProxyProvider<PlayerActionModel, PlayRoomModel>(
+              create: (context) => PlayRoomModel(),
+              update: (context, playerAction, playRoom) => playRoom..playerAction = playerAction,
+            )
+          ],
           child: Column(
             children: <Widget>[
               HumanLifeStages(),


### PR DESCRIPTION
## 概要

Model の Provider 扱いの流れを正常化するために、
PlayerActionModel の ChangeNotifier の扱い + その他  Model の修正を行った。

## 特に見て欲しいところ

* **PlayerActionModel の状態変化が、PlayRoomに伝わり、それを hook に Human の色んな処理を行う流れが確立していること**

## 参考リンク

* https://github.com/flutter/samples/tree/master/provider_shopper/lib
