### PR TITLE
temporary implement to gain money event

### DIFF
--- a/lib/models/common/life_event_executor.dart
+++ b/lib/models/common/life_event_executor.dart
@@ -1,0 +1,18 @@
+import '../play_room/life_stage.dart';
+import 'life_event.dart';
+import 'life_event_params/gain_life_items_params.dart';
+import 'life_event_params/life_event_params.dart';
+import 'life_item.dart';
+
+class LifeEventExecutor {
+  LifeStageModel executeEvent(LifeEventModel lifeEvent, LifeStageModel lifeStage) {
+    // FIXME: 他の EventType もサポートすること
+    if (lifeEvent.type != LifeEventType.gainLifeItems) return lifeStage;
+
+    final params = lifeEvent.params as GainLifeItemsParams;
+    final items = [
+      for (final item in params.targetItems) LifeItemModel(item.key, item.type, item.amount),
+    ];
+    return lifeStage..lifeItems.addAll(items);
+  }
+}

--- a/lib/models/common/life_item.dart
+++ b/lib/models/common/life_item.dart
@@ -10,7 +10,7 @@
 /// ```
 /// {@end-tool}
 class LifeItemModel {
-  LifeItemModel(this.key, this.type);
+  LifeItemModel(this.key, this.type, this.amount);
 
   final String key;
   final LifeItemType type;

--- a/lib/models/common/life_road.dart
+++ b/lib/models/common/life_road.dart
@@ -1,12 +1,11 @@
-import 'package:HumanLifeGame/models/common/life_event_params/target_life_item_params.dart';
-import 'package:HumanLifeGame/models/common/life_item.dart';
-
 import 'life_event.dart';
 import 'life_event_params/gain_life_items_params.dart';
 import 'life_event_params/goal_params.dart';
 import 'life_event_params/life_event_params.dart';
 import 'life_event_params/nothing_params.dart';
 import 'life_event_params/start_params.dart';
+import 'life_event_params/target_life_item_params.dart';
+import 'life_item.dart';
 import 'life_step.dart';
 
 class LifeRoadModel {

--- a/lib/models/common/life_road.dart
+++ b/lib/models/common/life_road.dart
@@ -1,3 +1,6 @@
+import 'package:HumanLifeGame/models/common/life_event_params/target_life_item_params.dart';
+import 'package:HumanLifeGame/models/common/life_item.dart';
+
 import 'life_event.dart';
 import 'life_event_params/gain_life_items_params.dart';
 import 'life_event_params/goal_params.dart';
@@ -22,7 +25,15 @@ class LifeRoadModel {
           final params = () {
             if (isStart) return const StartParams();
             if (isGoal) return const GoalParams();
-            if (y == 0) return const GainLifeItemsParams(targetItems: []);
+            if (y == 0) {
+              return const GainLifeItemsParams(targetItems: [
+                TargetLifeItemParams(
+                  key: 'money',
+                  type: LifeItemType.money,
+                  amount: 1000,
+                )
+              ]);
+            }
             return const NothingParams();
           }();
           return LifeStepModel(

--- a/lib/models/play_room/life_stage.dart
+++ b/lib/models/play_room/life_stage.dart
@@ -7,7 +7,14 @@ class LifeStageModel {
   LifeStageModel(this.human);
 
   HumanModel human;
-  List<LifeItemModel> lifeItems;
-  List<LifeEventModel> lifeEventRecord;
+  List<LifeItemModel> lifeItems = [];
+  List<LifeEventModel> lifeEventRecord = [];
   LifeStepModel lifeStepModel;
+
+  int get totalMoney => lifeItems.isEmpty
+      ? 0
+      : lifeItems
+          .where((item) => item.type == LifeItemType.money)
+          .map((money) => money.amount)
+          .reduce((val, el) => val + el);
 }

--- a/lib/models/play_room/play_room.dart
+++ b/lib/models/play_room/play_room.dart
@@ -1,3 +1,4 @@
+import 'package:HumanLifeGame/models/common/life_event_executor.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../i18n/i18n.dart';
@@ -38,6 +39,7 @@ class PlayRoomModel extends ChangeNotifier {
   }
 
   final I18n _i18n;
+  final _lifeEventExecutor = LifeEventExecutor();
 
   // 歩む対象となる人生
   final HumanLifeModel _humanLife;
@@ -55,7 +57,12 @@ class PlayRoomModel extends ChangeNotifier {
     announcement.message = _i18n.rollAnnouncement(_currentPlayer.name, playerAction.roll);
     // 人生を進める
     _moveLifeStep();
-    // TODO: LifeEvent 処理
+
+    // LifeEvent 処理
+    lifeStages[_currentPlayerLifeStageIndex] = _lifeEventExecutor.executeEvent(
+      _currentPlayerLifeStage.lifeStepModel.lifeEvent,
+      _currentPlayerLifeStage,
+    );
 
     // 全員がゴールに到着しているかどうかを確認
     _allHumansArrivedAtGoal = lifeStages.every((lifeStage) => lifeStage.lifeStepModel.isGoal);
@@ -80,6 +87,7 @@ class PlayRoomModel extends ChangeNotifier {
 
   // 参加者のそれぞれの人生の進捗
   List<LifeStageModel> lifeStages = [];
+
   int get _currentPlayerLifeStageIndex => lifeStages.indexWhere((lifeStage) => lifeStage.human == _currentPlayer);
   LifeStageModel get _currentPlayerLifeStage => lifeStages[_currentPlayerLifeStageIndex];
 

--- a/lib/models/play_room/play_room.dart
+++ b/lib/models/play_room/play_room.dart
@@ -1,10 +1,10 @@
-import 'package:HumanLifeGame/models/common/life_event_executor.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../i18n/i18n.dart';
 import '../common/human.dart';
 import '../common/human_life.dart';
 import '../common/life_event.dart';
+import '../common/life_event_executor.dart';
 import '../common/life_road.dart';
 import '../common/user.dart';
 import 'announcement.dart';

--- a/lib/screens/play_room/life_stages.dart
+++ b/lib/screens/play_room/life_stages.dart
@@ -12,7 +12,7 @@ class LifeStages extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Card(
         child: SizedBox(
-          width: 300,
+          width: 330,
           height: 500,
           child: _lifeStages(context),
         ),
@@ -31,7 +31,7 @@ class LifeStages extends StatelessWidget {
               child: (currentPlayer == lifeStage.human) ? currentPlayerSelector() : null,
             ),
             Text(lifeStage.human.name),
-            const Text(', money: '), // FIXME: 仮テキスト
+            const Text(', 💵: '), // FIXME: 仮テキスト
             Text(lifeStage.totalMoney.toString()),
           ],
         ),

--- a/lib/screens/play_room/life_stages.dart
+++ b/lib/screens/play_room/life_stages.dart
@@ -31,6 +31,8 @@ class LifeStages extends StatelessWidget {
               child: (currentPlayer == lifeStage.human) ? currentPlayerSelector() : null,
             ),
             Text(lifeStage.human.name),
+            const Text(', money: '), // FIXME: 仮テキスト
+            Text(lifeStage.totalMoney.toString()),
           ],
         ),
     ];

--- a/test/unit/models/life_stage_model_test.dart
+++ b/test/unit/models/life_stage_model_test.dart
@@ -1,0 +1,18 @@
+import 'package:HumanLifeGame/models/common/human.dart';
+import 'package:HumanLifeGame/models/common/life_item.dart';
+import 'package:HumanLifeGame/models/play_room/life_stage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('totalMoney', () {
+    final items = [
+      LifeItemModel('doctor', LifeItemType.job, 1),
+      LifeItemModel('money', LifeItemType.money, 200),
+      LifeItemModel('money', LifeItemType.money, 300),
+      LifeItemModel('money', LifeItemType.money, 100),
+      LifeItemModel('coffee', LifeItemType.coffee, 1),
+    ];
+    final lifeStageModel = LifeStageModel(HumanModel('human_1', 'foo'))..lifeItems = items;
+    expect(lifeStageModel.totalMoney, 600);
+  });
+}

--- a/test/widget/life_stage_test.dart
+++ b/test/widget/life_stage_test.dart
@@ -1,0 +1,50 @@
+import 'package:HumanLifeGame/i18n/i18n.dart';
+import 'package:HumanLifeGame/models/common/life_item.dart';
+import 'package:HumanLifeGame/models/play_room/play_room.dart';
+import 'package:HumanLifeGame/screens/play_room/life_stages.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'helper/widget_build_helper.dart';
+
+Future<void> main() async {
+  const locale = Locale('en', 'US');
+  final i18n = await I18n.load(locale);
+
+  testWidgets('show initial total moneys', (tester) async {
+    final playRoomModel = PlayRoomModel(i18n);
+    await tester.pumpWidget(testableApp(
+      locale: locale,
+      home: ChangeNotifierProvider(create: (_) => playRoomModel, child: const LifeStages()),
+    ));
+    await tester.pump();
+    expect(find.text('0'), findsNWidgets(2));
+  });
+
+  testWidgets('show variable total moneys', (tester) async {
+    final playRoomModel = PlayRoomModel(i18n);
+    for (final lifeStage in playRoomModel.lifeStages) {
+      lifeStage.lifeItems.add(LifeItemModel('key', LifeItemType.money, 200));
+    }
+    await tester.pumpWidget(testableApp(
+      locale: locale,
+      home: ChangeNotifierProvider(create: (_) => playRoomModel, child: const LifeStages()),
+    ));
+    await tester.pump();
+    expect(find.text('200'), findsNWidgets(2));
+  });
+
+  testWidgets('show current player', (tester) async {
+    final playRoomModel = PlayRoomModel(i18n);
+    await tester.pumpWidget(testableApp(
+      locale: locale,
+      home: ChangeNotifierProvider(create: (_) => playRoomModel, child: const LifeStages()),
+    ));
+    await tester.pump();
+    final currentPlayerSelector = find.byIcon(Icons.chevron_right);
+    final row = tester.element(currentPlayerSelector).findAncestorWidgetOfExactType<Row>();
+    final human1Name = find.text('human_1_name');
+    expect(row.children.contains(human1Name.evaluate().first.widget), true);
+  });
+}

--- a/test/widget/life_stage_test.dart
+++ b/test/widget/life_stage_test.dart
@@ -19,7 +19,7 @@ Future<void> main() async {
       home: ChangeNotifierProvider(create: (_) => playRoomModel, child: const LifeStages()),
     ));
     await tester.pump();
-    expect(find.text('0'), findsNWidgets(2));
+    expect(find.text('0'), findsNWidgets(playRoomModel.lifeStages.length));
   });
 
   testWidgets('show variable total moneys', (tester) async {
@@ -32,7 +32,7 @@ Future<void> main() async {
       home: ChangeNotifierProvider(create: (_) => playRoomModel, child: const LifeStages()),
     ));
     await tester.pump();
-    expect(find.text('200'), findsNWidgets(2));
+    expect(find.text('200'), findsNWidgets(playRoomModel.lifeStages.length));
   });
 
   testWidgets('show current player', (tester) async {
@@ -44,7 +44,7 @@ Future<void> main() async {
     await tester.pump();
     final currentPlayerSelector = find.byIcon(Icons.chevron_right);
     final row = tester.element(currentPlayerSelector).findAncestorWidgetOfExactType<Row>();
-    final human1Name = find.text('human_1_name');
-    expect(row.children, contains(human1Name.evaluate().first.widget));
+    final currentPlayerNameText = find.text(playRoomModel.currentPlayer.name);
+    expect(row.children, contains(currentPlayerNameText.evaluate().first.widget));
   });
 }

--- a/test/widget/life_stage_test.dart
+++ b/test/widget/life_stage_test.dart
@@ -45,6 +45,6 @@ Future<void> main() async {
     final currentPlayerSelector = find.byIcon(Icons.chevron_right);
     final row = tester.element(currentPlayerSelector).findAncestorWidgetOfExactType<Row>();
     final human1Name = find.text('human_1_name');
-    expect(row.children.contains(human1Name.evaluate().first.widget), true);
+    expect(row.children, contains(human1Name.evaluate().first.widget));
   });
 }


### PR DESCRIPTION
## 概要

GainLifeItem の仮実装を追加した。
money を獲得し、それを LifeStages Widget で表示するようにしている。
![image](https://user-images.githubusercontent.com/23427957/81484383-f8268f80-927f-11ea-96a9-7ea9d94a409c.png)

## 特に見て欲しいところ
* LifeStage に対して LifeEvent の処理を行うのを誰にやらせるか悩んだ結果、LifeStepModel や LifeEventModel が持っててもおかしいと考え、EventExecutor クラスを新設した点
* LifeItem の保持が、同一 type 同一 key でも別個になっている点。例えば、money 300 の獲得を二回した場合、money 300 の LifeItem が二個追加される。money 600 とはならない。どう思います?
