### PR TITLE
Hosting Dart Document on GitHub Page

### DIFF
--- a/.github/workflows/flutter_analyzer.yaml
+++ b/.github/workflows/flutter_analyzer.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_format.yaml
+++ b/.github/workflows/flutter_format.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_test.yaml
+++ b/.github/workflows/flutter_test.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_web_deploy.yaml
+++ b/.github/workflows/flutter_web_deploy.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/upload_dart_docs.yaml
+++ b/.github/workflows/upload_dart_docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: generate dart docs
         run: FLUTTER_ROOT=~/development/flutter dartdoc --output docs/
       - name: deploy
-        usees: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/.github/workflows/upload_dart_docs.yaml
+++ b/.github/workflows/upload_dart_docs.yaml
@@ -3,7 +3,6 @@ name: Upload_Dart_Docs
 on:
   push:
     branches:
-      - document_github_page # FIXME: delete
       - master
 
 jobs:

--- a/.github/workflows/upload_dart_docs.yaml
+++ b/.github/workflows/upload_dart_docs.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: flutter packages pub run build_runner build
       - name: generate dart docs
         run: FLUTTER_ROOT=$FLUTTER_HOME dartdoc --output docs/
-      - name: deploy
+      - name: upload
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload_dart_docs.yaml
+++ b/.github/workflows/upload_dart_docs.yaml
@@ -1,0 +1,30 @@
+name: Upload_Dart_Docs
+
+on:
+  push:
+    branches:
+      - document_github_page # FIXME: delete
+      - master
+
+jobs:
+  upload_dart_docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: 'beta'
+      - run: flutter config --enable-web
+      - run: flutter pub get
+      - run: flutter packages pub run build_runner build
+      - run: which flutter # 確認
+      - name: generate dart docs
+        run: FLUTTER_ROOT=~/development/flutter dartdoc --output docs/
+      - name: deploy
+        usees: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.github/workflows/upload_dart_docs.yaml
+++ b/.github/workflows/upload_dart_docs.yaml
@@ -20,9 +20,8 @@ jobs:
       - run: flutter config --enable-web
       - run: flutter pub get
       - run: flutter packages pub run build_runner build
-      - run: which flutter # 確認
       - name: generate dart docs
-        run: FLUTTER_ROOT=~/development/flutter dartdoc --output docs/
+        run: FLUTTER_ROOT=$FLUTTER_HOME dartdoc --output docs/
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 #.vscode/
 
 # Flutter/Dart/Pub related
-**/doc/api/
+**/docs/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ flutter packages pub run build_runner build
 
 ```sh
 # See: https://github.com/dart-lang/dartdoc/pull/2175
-FLUTTER_ROOT=~/development/flutter dartdoc --output doc/api && open doc/api/index.html
+FLUTTER_ROOT=~/development/flutter dartdoc --output docs && open docs/index.html
 ```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ flutter packages pub run build_runner build
 
 6. you can call `I18n.of(context).hoge`
 
-### [Document](https://github.com/dart-lang/dartdoc)
+### [API Document](https://github.com/dart-lang/dartdoc)
 
-```sh
-# See: https://github.com/dart-lang/dartdoc/pull/2175
-FLUTTER_ROOT=~/development/flutter dartdoc --output docs && open docs/index.html
-```
+See: https://sensuikan1973.github.io/HumanLifeGame/


### PR DESCRIPTION
## Overview

疲れたので息抜きに dartdoc で生成したドキュメントを GitHub page で見れる job を作った。
https://github.com/peaceiris/actions-gh-pages を使ってる。

See: https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site