### PR TITLE
add lobby page

### DIFF
--- a/lib/api/auth.dart
+++ b/lib/api/auth.dart
@@ -47,13 +47,14 @@ class Auth {
 
   /// 現在ログインしてるユーザのオブザーバ.
   /// See: <https://firebase.google.com/docs/auth/web/manage-users>
-  Stream<UserModel> get currentUserStream => _auth.onAuthStateChanged.asyncMap(_toModel);
+  Stream<UserModel> get currentUserStream =>
+      _auth.onAuthStateChanged.asyncMap((user) => user != null ? _toModel(user) : null);
 
   /// 現在ログインしてるユーザ.
   /// See: <https://firebase.google.com/docs/auth/web/manage-users>
   Future<UserModel> get currentUser async {
     final user = await _auth.currentUser();
-    return _toModel(user);
+    return user != null ? _toModel(user) : null;
   }
 
   Future<void> signOut() async => _auth.signOut();

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -8,6 +8,7 @@ import 'models/common/human_life.dart';
 import 'models/common/life_road.dart';
 import 'models/common/user.dart';
 import 'models/play_room/play_room.dart';
+import 'screens/lobby/lobby.dart';
 import 'screens/play_room/play_room.dart';
 import 'screens/sign_in/sign_in.dart';
 
@@ -15,11 +16,14 @@ import 'screens/sign_in/sign_in.dart';
 class Router {
   /// FIXME: 当然今だけ.
   String get initial => playRoom;
+
+  final String lobby = '/lobby';
   final String signIn = '/sign_in';
   final String playRoom = '/play_room';
 
   Map<String, WidgetBuilder> get routes => {
-        signIn: (context) => const SignIn(),
+        lobby: (_) => const Lobby(),
+        signIn: (_) => const SignIn(),
         playRoom: (context) => MultiProvider(
               providers: [
                 ChangeNotifierProvider<PlayRoomNotifier>(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -14,8 +14,7 @@ import 'screens/sign_in/sign_in.dart';
 
 @immutable
 class Router {
-  /// FIXME: 当然今だけ.
-  String get initial => playRoom;
+  String get initial => lobby;
 
   final String lobby = '/lobby';
   final String signIn = '/sign_in';

--- a/lib/screens/lobby/lobby.dart
+++ b/lib/screens/lobby/lobby.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class Lobby extends StatelessWidget {
+  const Lobby({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => Container();
+}

--- a/lib/screens/lobby/lobby.dart
+++ b/lib/screens/lobby/lobby.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import '../../router.dart';
+
+/// FIXME: ロジックべた書き
 class Lobby extends StatelessWidget {
   const Lobby({Key key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) => Container();
+  Widget build(BuildContext context) => Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              RaisedButton(
+                onPressed: () => Navigator.of(context).pushNamed(context.read<Router>().playRoom),
+                child: const Text('Go to PlayRoom'),
+              ),
+            ],
+          ),
+        ),
+      );
 }

--- a/test/widget/human_life_game_app_test.dart
+++ b/test/widget/human_life_game_app_test.dart
@@ -1,5 +1,5 @@
 import 'package:HumanLifeGame/human_life_game_app.dart';
-import 'package:HumanLifeGame/screens/play_room/play_room.dart';
+import 'package:HumanLifeGame/screens/lobby/lobby.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,16 +7,15 @@ import '../mocks/auth.dart';
 
 void main() {
   // Desktopの標準サイズ 1440x1024に設定
-  const windowWidth = 1440.0;
-  const windowHeight = 1024.0;
-  const size = Size(windowWidth, windowHeight);
+  const size = Size(1440, 1024);
   setUp(() {
     // See: https://github.com/flutter/flutter/issues/12994#issuecomment-397321431
     WidgetsBinding.instance.renderView.configuration = TestViewConfiguration(size: size);
   });
-  testWidgets('show PlayRoom', (tester) async {
+
+  testWidgets('show Lobby', (tester) async {
     await tester.pumpWidget(HumanLifeGameApp.inProviders(auth: MockAuth()));
     await tester.pump();
-    expect(find.byType(PlayRoom), findsOneWidget);
+    expect(find.byType(Lobby), findsOneWidget);
   });
 }

--- a/web/init_firebase.js
+++ b/web/init_firebase.js
@@ -7,4 +7,5 @@ if(window.location.hostname === 'localhost'){
 fetch(config_url).then( res => res.json() ).then( json => {
  firebase.initializeApp(json);
  firebase.analytics();
+// firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL);
 });

--- a/web/init_firebase.js
+++ b/web/init_firebase.js
@@ -7,5 +7,7 @@ if(window.location.hostname === 'localhost'){
 fetch(config_url).then( res => res.json() ).then( json => {
  firebase.initializeApp(json);
  firebase.analytics();
-// firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL);
+ // See: https://firebase.google.com/docs/auth/web/auth-state-persistence
+ // See: https://github.com/FirebaseExtended/flutterfire/issues/1714
+ // firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL);
 });


### PR DESCRIPTION
## Overview

この PR は Lobby ページを踏んでから PlayRoom に移るのを実装しただけのもの。

今後の見通しを以下にざっくり書いたので目を通しておいてもらえると。

### 今後の見通し
以下のように play を制御するものとする。
※ なお、Lobby ページ(= トップページ)訪問時に、匿名認証はすぐに踏ませる。その上で、一部機能を利用しようとしたら、SignIn ページに飛ばす。

| 機能 ＼ 認証状態 | 匿名 | メールリンク | 
|---|---|---|
| Lobby 閲覧 | ○ | ○|
| PlayRoom 入室&遊ぶ | ○ | ○|
| 表示名編集 | × (自動割当) | ○ |
| 他人の LifeRoad 閲覧 | ○ | ○ |
| LifeRoad 作成 | × | ○|
| マイページ | △ (編集不可,自作Road一覧は勿論ゼロ) | ○ |