### PR TITLE
use cloud_firstore_mocks & add test

### DIFF
--- a/lib/api/firestore/service_control.dart
+++ b/lib/api/firestore/service_control.dart
@@ -15,12 +15,14 @@ abstract class ServiceControl with _$ServiceControl {
     @TimestampConverter() DateTime updatedAt,
   }) = _ServiceControl;
   factory ServiceControl.fromJson(Map<String, dynamic> json) => _$ServiceControlFromJson(json);
+
+  @visibleForTesting
+  static const collectionId = 'serviceControl';
 }
 
-const _collectionId = 'serviceControl';
-
+/// TODO: 関数直置きママでいいかは追々検討
 CollectionRef<ServiceControl, Document<ServiceControl>> serviceControlsRef(Store store) => CollectionRef(
-      store.firestore.collection(_collectionId),
+      store.firestore.collection(ServiceControl.collectionId),
       decoder: (snapshot) => Document(snapshot.reference, ServiceControl.fromJson(snapshot.data)),
       encoder: (serviceControl) => replacingTimestamp(
         json: serviceControl.toJson(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -120,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.6"
+  cloud_firestore_mocks:
+    dependency: "direct dev"
+    description:
+      name: cloud_firestore_mocks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.4"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   cupertino_icons: 0.1.3
   email_validator: 1.0.4
   firebase_auth: 0.16.0
-  firestore_ref: ^0.8.10
+  firestore_ref: 0.8.10
   flutter_dotenv: 2.1.0
   freezed_annotation: 0.7.1
   provider: 4.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
     sdk: flutter
 
   build_runner: 1.10.0
+  cloud_firestore_mocks: 0.4.4
   dartman_sensuikan1973:
     git:
       url: https://github.com/sensuikan1973/dartman_sensuikan1973

--- a/test/widget/maintenance_test.dart
+++ b/test/widget/maintenance_test.dart
@@ -1,0 +1,55 @@
+import 'package:HumanLifeGame/api/firestore/firestore.dart';
+import 'package:HumanLifeGame/api/firestore/service_control.dart';
+import 'package:HumanLifeGame/screens/maintenance/maintenance.dart';
+import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  testWidgets('not under maintenance', (tester) async {
+    final serviceControlData = {
+      ServiceControlField.isMaintenance: false,
+      ServiceControlField.updatedAt: DateTime.now(),
+      ServiceControlField.requiredMinVersion: 'X.Y.Z',
+    };
+    final firestore = MockFirestoreInstance();
+    await firestore
+        .collection(ServiceControl.collectionId)
+        .document(ServiceControlDocId.web)
+        .setData(serviceControlData);
+
+    await tester.pumpWidget(
+      Provider<Store>(
+        create: (context) => Store(firestore),
+        child: const MaterialApp(home: Maintenance()),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(Maintenance), findsOneWidget);
+    expect(find.text('not under maintenance'), findsOneWidget);
+  });
+
+  testWidgets('under maintenance', (tester) async {
+    final serviceControlData = {
+      ServiceControlField.isMaintenance: true,
+      ServiceControlField.updatedAt: DateTime.now(),
+      ServiceControlField.requiredMinVersion: 'X.Y.Z',
+    };
+    final firestore = MockFirestoreInstance();
+    await firestore
+        .collection(ServiceControl.collectionId)
+        .document(ServiceControlDocId.web)
+        .setData(serviceControlData);
+
+    await tester.pumpWidget(
+      Provider<Store>(
+        create: (context) => Store(firestore),
+        child: const MaterialApp(home: Maintenance()),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(Maintenance), findsOneWidget);
+    expect(find.text('under maintenance'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Overview

Firestore の繋ぎ込みが済み、いよいよ読み書きしていくことになる。
Widget Test では当然 mock することになるわけだが、愚直に mockito で mock するとダルすぎて悲しみに暮れるので、[wrapper](https://github.com/atn832/cloud_firestore_mocks) を採用する。
ただし、CollectionGroup Query に対応していない等の機能不足があるため、必要に応じて PR 作って contribute するつもり。それを手間と捉えたとしても、過去の経験的に、愚直に mock するより楽だと断言できます。

ちなみに、Firestore を触る処理を特定レイヤー(Repository)に閉じ込めて、それを mock するのも手ではあるが、以下3点を理由に、Firestore 自体の mock 方針を選んだ。

* Repository に隠蔽してそれを mock する場合、write のモックが面倒。write 処理ごとに mock 処理を更新しないといけない。
  * 対して Firestore ごとであれば、write で `実際に書き込み(データの更新/作成)がおこなわれたもの` として処理が進む
* Firestore に関する serialize, deserialize 処理といった近辺処理も込みでテストできるのが嬉しい
* そもそも Repository なるものの登場予定なし。(See: https://github.com/sensuikan1973/HumanLifeGame/pull/153)

## Reference
* https://github.com/atn832/cloud_firestore_mocks
* https://github.com/sensuikan1973/cloud_firestore_mocks
  * 多分 CollectionGroupQuery は PR 送んないとサポートされないかな。必要になった時に未実装だったら PR 送る。