### PR TITLE
codecov ignore Auth wrapper

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -33,3 +33,4 @@ comment: # See: https://docs.codecov.io/docs/pull-request-comments
 
 ignore: # See: https://docs.codecov.io/docs/ignoring-paths
   - "lib/i18n"
+  - "lib/api/auth"


### PR DESCRIPTION
## Overview

対して firestore は Firestore.instance レベルでモックするから含めたままでいいや
