### PR TITLE
remove unnecessary arg for codecov actions

### DIFF
--- a/.github/workflows/flutter_test.yaml
+++ b/.github/workflows/flutter_test.yaml
@@ -22,5 +22,4 @@ jobs:
       - run: flutter test --no-test-assets --coverage --coverage-path=~/coverage/lcov.info
       - uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ~/coverage/lcov.info


### PR DESCRIPTION
## Overview

不要な設定を除く
See: https://github.com/marketplace/actions/codecov#usage


これで test job 内のリトライチャレンジがなくなるはず。test が無駄に遅いことがあった問題を解消できるはず。