### PR TITLE
change package management

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -19,12 +19,9 @@ jobs:
 
         # See: https://pub.dev/packages/pubspec_update
         # 公式で yarn upgrade --latest 相当のことができるコマンドが用意されてないので、サードパーティの package を使う
+        # Ref: https://github.com/flutter/flutter/issues/12627
       - run: pub global activate pubspec_update
       - run: pub global run pubspec_update:pubspec-update --force  # See: https://dart.dev/tools/pub/cmd/pub-global#running-a-script-using-pub-global-run
-      - name: edit pubspec.yaml
-        run: |
-          # NOTE: pubspec_update は「^」で管理するため。本当は package に PR 送るのが望ましい。
-          sed -i -e 's/\^//' pubspec.yaml
       - name: create PR
         uses: peter-evans/create-pull-request@v2
         with:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -379,7 +379,7 @@ packages:
       name: intl_translation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.9"
+    version: "0.17.10"
   io:
     dependency: transitive
     description:
@@ -491,7 +491,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -512,7 +512,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
+    version: "4.1.3"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,29 +17,29 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  cupertino_icons: 0.1.3
-  email_validator: 1.0.4
-  firebase_auth: 0.16.1
-  firestore_ref: 0.8.13
-  flutter_dotenv: 2.1.0
-  freezed_annotation: 0.7.1
-  provider: 4.1.2
-  shared_preferences: 0.5.7+3
+  cupertino_icons: ^0.1.3
+  email_validator: ^1.0.4
+  firebase_auth: ^0.16.1
+  firestore_ref: ^0.8.13
+  flutter_dotenv: ^2.1.0
+  freezed_annotation: ^0.7.1
+  provider: ^4.1.3
+  shared_preferences: ^0.5.7+3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: 1.10.0
-  cloud_firestore_mocks: 0.4.4
+  build_runner: ^1.10.0
+  cloud_firestore_mocks: ^0.4.4
   dartman_sensuikan1973:
     git:
       url: https://github.com/sensuikan1973/dartman_sensuikan1973
       ref: 1.0.0
-  freezed: 0.10.9
-  json_serializable: 3.3.0
-  intl_translation: 0.17.9
-  mockito: 4.1.1
+  freezed: ^0.10.9
+  json_serializable: ^3.3.0
+  intl_translation: ^0.17.9
+  mockito: ^4.1.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Overview
当面は cron job で pubspec_update 使って更新しまくっていく、と言って job 追加してあったんだけど、pubspec の記法変えるの忘れてマトモに動いてなかった...

というわけで修正しやす

現状 lock ファイルを commit  してるからこのママ運用でも問題は起きない。lock ファイルを ignore してる場合 ^ で管理するのは危険だけどね。

## Reference
* https://pub.dev/packages/pubspec_update
  * flutter にも `yarn upgrade --latest` 相当のコマンド欲しいなぁ...
最近 `pub outdated` が追加されたので、いずれ追加されるのかなぁとは思うけど。
* https://github.com/flutter/flutter/issues/12627