### PR TITLE
add joinPlayRoom filed on user

### DIFF
--- a/lib/api/firestore/user.dart
+++ b/lib/api/firestore/user.dart
@@ -11,6 +11,7 @@ abstract class User with _$User {
   const factory User({
     @required String uid,
     @required String displayName,
+    @required @DocumentReferenceConverter() DocumentReference joinPlayRoom,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _User;
@@ -26,4 +27,7 @@ class UserField {
 
   /// displayName (by Auth)
   static const displayName = 'displayName';
+
+  /// 参加中の playRoom
+  static const joinPlayRoom = 'joinPlayRoom';
 }


### PR DESCRIPTION
## Overview

詳細は https://github.com/sensuikan1973/HumanLifeGame_Server/pull/43 を見て。

簡単にいうと、playRoom の document id を uid にすることで一人１つ制約を設けるシンプルな方針でいたんだけど、それだと host 委譲機能に対応するのが困難なので、ロジックは複雑になるが 1人1つ制約を document id ではなく参照で実現するようにする っていう話。