### PR TITLE
add timestamp on lifeItem schema

### DIFF
--- a/lib/api/firestore/life_item.dart
+++ b/lib/api/firestore/life_item.dart
@@ -1,3 +1,4 @@
+import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -11,6 +12,8 @@ abstract class LifeItem with _$LifeItem {
     @required String type,
     @required String key,
     @required int amount,
+    @required @TimestampConverter() DateTime createdAt,
+    @required @TimestampConverter() DateTime updatedAt,
   }) = _LifeItem;
   factory LifeItem.fromJson(Map<String, dynamic> json) => _$LifeItemFromJson(json);
 


### PR DESCRIPTION
## Overview

See: https://github.com/sensuikan1973/HumanLifeGame_Server/pull/47
See: https://github.com/sensuikan1973/HumanLifeGame_Server/pull/48

timestamp いらないと思ってたけど、上書き仕様(job 転職など) や ソート(これはなくてもいけるけど)、不正検知 とかを考えると、入れたくなった