### PR TITLE
create public playRoom in Lobby

### DIFF
--- a/lib/api/firestore/entity.dart
+++ b/lib/api/firestore/entity.dart
@@ -1,4 +1,6 @@
 // ignore: one_member_abstracts
 abstract class Entity {
   Map<String, dynamic> toJson();
+
+  Map<String, dynamic> encode();
 }

--- a/lib/api/firestore/life_event.dart
+++ b/lib/api/firestore/life_event.dart
@@ -1,22 +1,27 @@
+import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'entity.dart';
 
 part 'life_event.freezed.dart';
 part 'life_event.g.dart';
 
 /// Map Value on Firestore
 @freezed
-abstract class LifeEvent with _$LifeEvent {
+abstract class LifeEvent implements _$LifeEvent, Entity {
   const factory LifeEvent({
     @required String type,
     @required String target,
     @required String description,
     @required Map<String, dynamic> params,
   }) = _LifeEvent;
+  const LifeEvent._();
+
   factory LifeEvent.fromJson(Map<String, dynamic> json) => _$LifeEventFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'lifeEvent';
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class LifeEventField {

--- a/lib/api/firestore/life_event_record.dart
+++ b/lib/api/firestore/life_event_record.dart
@@ -2,6 +2,7 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'entity.dart';
 import 'life_event.dart';
 
 part 'life_event_record.freezed.dart';
@@ -9,16 +10,18 @@ part 'life_event_record.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class LifeEventRecord with _$LifeEventRecord {
+abstract class LifeEventRecord implements _$LifeEventRecord, Entity {
   const factory LifeEventRecord({
     @required String humanId,
     @required LifeEvent lifeEvent,
     @required @TimestampConverter() DateTime createdAt,
   }) = _LifeEventRecord;
+  const LifeEventRecord._();
+
   factory LifeEventRecord.fromJson(Map<String, dynamic> json) => _$LifeEventRecordFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'lifeEventRecord';
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class LifeEventRecordField {

--- a/lib/api/firestore/life_item.dart
+++ b/lib/api/firestore/life_item.dart
@@ -2,12 +2,14 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'entity.dart';
+
 part 'life_item.freezed.dart';
 part 'life_item.g.dart';
 
 /// Map Value on Firestore
 @freezed
-abstract class LifeItem with _$LifeItem {
+abstract class LifeItem implements _$LifeItem, Entity {
   const factory LifeItem({
     @required String type,
     @required String key,
@@ -15,10 +17,12 @@ abstract class LifeItem with _$LifeItem {
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _LifeItem;
+  const LifeItem._();
+
   factory LifeItem.fromJson(Map<String, dynamic> json) => _$LifeItemFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'lifeItem';
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class LifeItemField {

--- a/lib/api/firestore/life_road.dart
+++ b/lib/api/firestore/life_road.dart
@@ -2,6 +2,7 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'entity.dart';
 import 'life_event.dart';
 
 part 'life_road.freezed.dart';
@@ -9,7 +10,7 @@ part 'life_road.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class HumanLife with _$HumanLife {
+abstract class HumanLife implements _$HumanLife, Entity {
   const factory HumanLife({
     @required @DocumentReferenceConverter() DocumentReference author,
     @required String title,
@@ -17,10 +18,12 @@ abstract class HumanLife with _$HumanLife {
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _HumanLife;
+  const HumanLife._();
+
   factory HumanLife.fromJson(Map<String, dynamic> json) => _$HumanLifeFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'humanLife';
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class HumanLifeField {

--- a/lib/api/firestore/life_stage.dart
+++ b/lib/api/firestore/life_stage.dart
@@ -2,22 +2,26 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'entity.dart';
+
 part 'life_stage.freezed.dart';
 part 'life_stage.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class LifeStage with _$LifeStage {
+abstract class LifeStage implements _$LifeStage, Entity {
   const factory LifeStage({
     @required @DocumentReferenceConverter() DocumentReference human,
     @required String currentLifeStepId,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _LifeStage;
+  const LifeStage._();
+
   factory LifeStage.fromJson(Map<String, dynamic> json) => _$LifeStageFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'lifeStage';
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class LifeStageField {

--- a/lib/api/firestore/play_room.dart
+++ b/lib/api/firestore/play_room.dart
@@ -2,6 +2,7 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'entity.dart';
 import 'life_event_record.dart';
 import 'life_stage.dart';
 
@@ -14,7 +15,7 @@ part 'play_room.g.dart';
 /// TODO: announcement はクライアントサイド完結想定だが、必要になったら追加.
 /// TODO: finishedAt は削除ロジックに使う想定だが、不要だったら削除. まだロジックを考え中.
 @freezed
-abstract class PlayRoom with _$PlayRoom {
+abstract class PlayRoom implements _$PlayRoom, Entity {
   const factory PlayRoom({
     @required @DocumentReferenceConverter() DocumentReference host,
     @required String title,
@@ -27,19 +28,12 @@ abstract class PlayRoom with _$PlayRoom {
     @required @TimestampConverter() DateTime updatedAt,
 //    @TimestampConverter() DateTime finishedAt,
   }) = _PlayRoom;
+  const PlayRoom._();
+
   factory PlayRoom.fromJson(Map<String, dynamic> json) => _$PlayRoomFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'playRoom';
-}
-
-class PlayRoomsRef extends CollectionRef<PlayRoom, Document<PlayRoom>> {
-  PlayRoomsRef(Firestore firestore)
-      : super(
-          firestore.collection(PlayRoom.collectionId),
-          decoder: (snapshot) => Document(snapshot.reference, PlayRoom.fromJson(snapshot.data)),
-          encoder: (serviceControl) => replacingTimestamp(json: serviceControl.toJson()),
-        );
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class PlayRoomField {

--- a/lib/api/firestore/play_room.dart
+++ b/lib/api/firestore/play_room.dart
@@ -24,8 +24,8 @@ abstract class PlayRoom implements _$PlayRoom, Entity {
     @required List<LifeEventRecord> everyLifeEventRecords,
     @required List<LifeStage> lifeStages,
     @required String currentTurnHumanId,
-    @required @TimestampConverter() DateTime createdAt,
-    @required @TimestampConverter() DateTime updatedAt,
+    @TimestampConverter() DateTime createdAt,
+    @TimestampConverter() DateTime updatedAt,
 //    @TimestampConverter() DateTime finishedAt,
   }) = _PlayRoom;
   const PlayRoom._();

--- a/lib/api/firestore/play_room.dart
+++ b/lib/api/firestore/play_room.dart
@@ -3,8 +3,6 @@ import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'entity.dart';
-import 'life_event_record.dart';
-import 'life_stage.dart';
 
 part 'play_room.freezed.dart';
 part 'play_room.g.dart';
@@ -21,8 +19,6 @@ abstract class PlayRoom implements _$PlayRoom, Entity {
     @required String title,
     @required @DocumentReferenceListConverter() List<DocumentReference> humans,
     @required @DocumentReferenceConverter() DocumentReference lifeRoad,
-    @required List<LifeEventRecord> everyLifeEventRecords,
-    @required List<LifeStage> lifeStages,
     @required String currentTurnHumanId,
     @TimestampConverter() DateTime createdAt,
     @TimestampConverter() DateTime updatedAt,

--- a/lib/api/firestore/service_control.dart
+++ b/lib/api/firestore/service_control.dart
@@ -22,6 +22,11 @@ abstract class ServiceControl implements _$ServiceControl, Entity {
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
+
+  static Document<ServiceControl> decode(DocumentSnapshot snapshot) => Document<ServiceControl>(
+        snapshot.reference,
+        ServiceControl.fromJson(snapshot.data),
+      );
 }
 
 class ServiceControlField {

--- a/lib/api/firestore/service_control.dart
+++ b/lib/api/firestore/service_control.dart
@@ -9,14 +9,19 @@ part 'service_control.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class ServiceControl with _$ServiceControl implements Entity {
+abstract class ServiceControl implements _$ServiceControl, Entity {
   const factory ServiceControl({
     @required bool isMaintenance,
     @required String requiredMinVersion,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _ServiceControl;
+  const ServiceControl._();
+
   factory ServiceControl.fromJson(Map<String, dynamic> json) => _$ServiceControlFromJson(json);
+
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class ServiceControlField {

--- a/lib/api/firestore/store.dart
+++ b/lib/api/firestore/store.dart
@@ -19,16 +19,13 @@ class Store {
 
   CollectionRef<T, Document<T>> collectionRef<T extends Entity>() => CollectionRef(
         firestore.collection(getCollectionId<T>()),
-        decoder: (snapshot) => Document(
-          snapshot.reference,
-          _jsonFactory<T>(snapshot.data),
-        ),
+        decoder: (snapshot) => _decode<T>(snapshot),
         encoder: (entity) => entity.encode(),
       );
 
   // 関連: https://stackoverflow.com/a/55237197/10928938
-  T _jsonFactory<T extends Entity>(Map<String, dynamic> json) {
-    if (T == ServiceControl) return ServiceControl.fromJson(json) as T;
+  Document<T> _decode<T extends Entity>(DocumentSnapshot snapshot) {
+    if (T == ServiceControl) return ServiceControl.decode(snapshot) as Document<T>;
     throw Error(); // unexpected
   }
 

--- a/lib/api/firestore/store.dart
+++ b/lib/api/firestore/store.dart
@@ -22,12 +22,12 @@ class Store {
   // 関連: https://stackoverflow.com/a/55237197/10928938
   T _jsonFactory<T extends Entity>(Map<String, dynamic> json) {
     if (T == ServiceControl) return ServiceControl.fromJson(json) as T;
-    return null;
+    throw Error(); // unexpected
   }
 
   @visibleForTesting
   String getCollectionId<T>() {
     if (T == ServiceControl) return 'serviceControl';
-    throw Error();
+    throw Error(); // unexpected
   }
 }

--- a/lib/api/firestore/store.dart
+++ b/lib/api/firestore/store.dart
@@ -2,7 +2,14 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 
 import 'entity.dart';
+import 'life_event.dart';
+import 'life_event_record.dart';
+import 'life_item.dart';
+import 'life_road.dart';
+import 'life_stage.dart';
+import 'play_room.dart';
 import 'service_control.dart';
+import 'user.dart';
 
 @immutable
 class Store {
@@ -16,7 +23,7 @@ class Store {
           snapshot.reference,
           _jsonFactory<T>(snapshot.data),
         ),
-        encoder: (entity) => replacingTimestamp(json: entity.toJson()),
+        encoder: (entity) => entity.encode(),
       );
 
   // 関連: https://stackoverflow.com/a/55237197/10928938
@@ -28,6 +35,13 @@ class Store {
   @visibleForTesting
   String getCollectionId<T>() {
     if (T == ServiceControl) return 'serviceControl';
+    if (T == LifeEvent) return 'lifeEvent';
+    if (T == LifeEventRecord) return 'lifeEventRecord';
+    if (T == LifeItem) return 'lifeItem';
+    if (T == HumanLife) return 'humanLife';
+    if (T == LifeStage) return 'LifeStage';
+    if (T == PlayRoom) return 'playRoom';
+    if (T == User) return 'user';
     throw Error(); // unexpected
   }
 }

--- a/lib/api/firestore/store.dart
+++ b/lib/api/firestore/store.dart
@@ -23,6 +23,11 @@ class Store {
         encoder: (entity) => entity.encode(),
       );
 
+  DocumentRef<T, Document<T>> docRef<T extends Entity>(String documentId) => DocumentRef(
+        collectionRef: collectionRef<T>(),
+        id: documentId,
+      );
+
   // 関連: https://stackoverflow.com/a/55237197/10928938
   Document<T> _decode<T extends Entity>(DocumentSnapshot snapshot) {
     if (T == ServiceControl) return ServiceControl.decode(snapshot) as Document<T>;

--- a/lib/api/firestore/user.dart
+++ b/lib/api/firestore/user.dart
@@ -2,12 +2,14 @@ import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'entity.dart';
+
 part 'user.freezed.dart';
 part 'user.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class User with _$User {
+abstract class User implements _$User, Entity {
   const factory User({
     @required String uid,
     @required String displayName,
@@ -15,10 +17,12 @@ abstract class User with _$User {
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _User;
+  const User._();
+
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
-  @visibleForTesting
-  static const collectionId = 'user';
+  @override
+  Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
 class UserField {

--- a/lib/models/lobby/lobby_notifier.dart
+++ b/lib/models/lobby/lobby_notifier.dart
@@ -1,3 +1,26 @@
+import '../../api/auth.dart';
+import '../../api/firestore/play_room.dart';
+import '../../api/firestore/store.dart';
+import '../../api/firestore/user.dart';
+
 class LobbyNotifier {
-  LobbyNotifier();
+  LobbyNotifier(this._auth, this._store);
+
+  final Auth _auth;
+  final Store _store;
+
+  Future<void> createPublicPlayRoom() async {
+    final user = await _auth.currentUser;
+    final userRef = _store.docRef<User>(user.id).ref;
+    final room = PlayRoom(
+      host: userRef,
+      title: 'はじめての人生',
+      humans: [userRef],
+      lifeRoad: userRef, // FIXME: null 禁止だからテキトーに入れてるだけで絶対に修正しないとダメ
+      everyLifeEventRecords: [],
+      lifeStages: [],
+      currentTurnHumanId: user.id,
+    );
+    await _store.collectionRef<PlayRoom>().add(room);
+  }
 }

--- a/lib/models/lobby/lobby_notifier.dart
+++ b/lib/models/lobby/lobby_notifier.dart
@@ -1,5 +1,5 @@
 import 'package:firestore_ref/firestore_ref.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../api/auth.dart';
 import '../../api/firestore/play_room.dart';

--- a/lib/models/lobby/lobby_notifier.dart
+++ b/lib/models/lobby/lobby_notifier.dart
@@ -1,9 +1,13 @@
+import 'package:firestore_ref/firestore_ref.dart';
+import 'package:flutter/material.dart';
+
 import '../../api/auth.dart';
 import '../../api/firestore/play_room.dart';
 import '../../api/firestore/store.dart';
 import '../../api/firestore/user.dart';
 
-class LobbyNotifier {
+// TODO: ValueNotifier に
+class LobbyNotifier extends ChangeNotifier {
   LobbyNotifier(this._auth, this._store);
 
   final Auth _auth;
@@ -11,16 +15,26 @@ class LobbyNotifier {
 
   Future<void> createPublicPlayRoom() async {
     final user = await _auth.currentUser;
-    final userRef = _store.docRef<User>(user.id).ref;
+    final userDocRef = _store.docRef<User>(user.id);
     final room = PlayRoom(
-      host: userRef,
+      host: userDocRef.ref,
       title: 'はじめての人生',
-      humans: [userRef],
-      lifeRoad: userRef, // FIXME: null 禁止だからテキトーに入れてるだけで絶対に修正しないとダメ
-      everyLifeEventRecords: [],
-      lifeStages: [],
+      humans: [userDocRef.ref],
+      // FIXME: null 禁止だからテキトーに入れてるだけで絶対に修正しないとダメ
+      //        rules 側に存否チェックが無いからこれ通るけど、ホント一時的なダミー実装に過ぎない
+      lifeRoad: userDocRef.ref,
       currentTurnHumanId: user.id,
     );
-    await _store.collectionRef<PlayRoom>().add(room);
+    final roomDocRef = _store.collectionRef<PlayRoom>().docRef();
+    final batch = _store.firestore.batch();
+    await roomDocRef.setData(room.encode(), batch: batch);
+    await userDocRef.updateData(
+      <String, dynamic>{
+        UserField.joinPlayRoom: roomDocRef.ref,
+        TimestampField.updatedAt: FieldValue.serverTimestamp(),
+      },
+      batch: batch,
+    );
+    await batch.commit();
   }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -22,32 +22,29 @@ class Router {
   final String playRoom = '/play_room';
   final String maintenance = '/maintenance';
 
+  // TODO: provider の移動
   Map<String, WidgetBuilder> get routes => {
         lobby: (_) => const Lobby(),
         signIn: (_) => const SignIn(),
         maintenance: (_) => const Maintenance(),
-        playRoom: (context) => MultiProvider(
-              providers: [
-                ChangeNotifierProvider<PlayRoomNotifier>(
-                  create: (_) => PlayRoomNotifier(
-                    I18n.of(context),
-                    context.read<Dice>(),
-                    HumanLifeModel(
-                      title: 'dummy HumanLife',
-                      author: UserModel(id: '123', name: 'dummyUser', isAnonymous: true),
-                      lifeRoad: LifeRoadModel(
-                        lifeStepsOnBoard: LifeRoadModel.createLifeStepsOnBoard(
-                          LifeRoadModel.dummyLifeEvents(),
-                        ),
-                      ),
+        playRoom: (context) => ChangeNotifierProvider<PlayRoomNotifier>(
+              create: (_) => PlayRoomNotifier(
+                I18n.of(context),
+                context.read<Dice>(),
+                HumanLifeModel(
+                  title: 'dummy HumanLife',
+                  author: UserModel(id: '123', name: 'dummyUser', isAnonymous: true),
+                  lifeRoad: LifeRoadModel(
+                    lifeStepsOnBoard: LifeRoadModel.createLifeStepsOnBoard(
+                      LifeRoadModel.dummyLifeEvents(),
                     ),
-                    [
-                      const HumanModel(id: '1', name: 'hoge', order: 0),
-                      const HumanModel(id: '2', name: 'fuga', order: 1),
-                    ],
                   ),
-                )
-              ],
+                ),
+                [
+                  const HumanModel(id: '1', name: 'hoge', order: 0),
+                  const HumanModel(id: '2', name: 'fuga', order: 1),
+                ],
+              ),
               child: const PlayRoom(),
             ),
       };

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'api/auth.dart';
 import 'api/dice.dart';
+import 'api/firestore/store.dart';
 import 'i18n/i18n.dart';
 import 'models/common/human.dart';
 import 'models/common/human_life.dart';
 import 'models/common/life_road.dart';
 import 'models/common/user.dart';
+import 'models/lobby/lobby_notifier.dart';
 import 'models/play_room/play_room_notifier.dart';
 import 'screens/lobby/lobby.dart';
 import 'screens/maintenance/maintenance.dart';
@@ -24,7 +27,10 @@ class Router {
 
   // TODO: provider の移動
   Map<String, WidgetBuilder> get routes => {
-        lobby: (_) => const Lobby(),
+        lobby: (_) => ChangeNotifierProvider(
+              create: (context) => LobbyNotifier(context.read<Auth>(), context.read<Store>()),
+              child: const Lobby(),
+            ),
         signIn: (_) => const SignIn(),
         maintenance: (_) => const Maintenance(),
         playRoom: (context) => ChangeNotifierProvider<PlayRoomNotifier>(

--- a/lib/screens/lobby/lobby.dart
+++ b/lib/screens/lobby/lobby.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../../api/auth.dart';
 import '../../models/common/user.dart';
+import '../../models/lobby/lobby_notifier.dart';
 import 'app_bar.dart';
 import 'human_life_tips.dart';
 import 'room_list_item.dart';
@@ -33,7 +34,7 @@ class Lobby extends StatelessWidget {
                     Stack(
                       children: [
                         _roomList(),
-                        Positioned(bottom: 0, right: 0, child: _createRoomButton()),
+                        Positioned(bottom: 0, right: 0, child: _createRoomButton(context)),
                       ],
                     ),
                     const HumanLifeTips(),
@@ -46,10 +47,10 @@ class Lobby extends StatelessWidget {
         ),
       );
 
-  FloatingActionButton _createRoomButton() => FloatingActionButton(
-        tooltip: 'create PlayRoom',
+  FloatingActionButton _createRoomButton(BuildContext context) => FloatingActionButton(
+        tooltip: 'create public PlayRoom',
         backgroundColor: Colors.indigo,
-        onPressed: () => debugPrint('TODO: create PlayRoom'),
+        onPressed: () async => context.read<LobbyNotifier>().createPublicPlayRoom(),
         child: const Icon(Icons.add),
       );
 

--- a/lib/screens/maintenance/maintenance.dart
+++ b/lib/screens/maintenance/maintenance.dart
@@ -14,7 +14,7 @@ class Maintenance extends StatelessWidget {
   Widget build(BuildContext context) => Scaffold(
         body: Center(
           child: StreamBuilder<Document<ServiceControl>>(
-            stream: context.watch<Store>().collectionRef<ServiceControl>().docRef(ServiceControlDocId.web).document(),
+            stream: context.watch<Store>().docRef<ServiceControl>(ServiceControlDocId.web).document(),
             builder: (context, snap) {
               if (!snap.hasData) return const Text('no data');
               return snap.data.entity.isMaintenance


### PR DESCRIPTION
## Overview

Lobby から playRoom を作成する。口頭で話したように、しばらくは public のみを考える。

また、firestore emulator の初期データセットアップ script がまだ無いので、地道に手で入れて data を export しておき、次回起動時にそれを読み込む必要がある。
emulator で auth が機能しないこともあって面倒なので、server 側に script を用意しておきたさ。

## Review Point
* placeholder になってるリストアイテムから、最初の参加者として join することを `public playRoom の作成` と呼んでいる。