### PR TITLE
navigate to play room

### DIFF
--- a/lib/api/firestore/life_event.dart
+++ b/lib/api/firestore/life_event.dart
@@ -7,24 +7,23 @@ import 'entity.dart';
 part 'life_event.freezed.dart';
 part 'life_event.g.dart';
 
-/// Map Value on Firestore
 @freezed
-abstract class LifeEvent implements _$LifeEvent, Entity {
-  const factory LifeEvent({
+abstract class LifeEventEntity implements _$LifeEventEntity, Entity {
+  const factory LifeEventEntity({
     @required String type,
     @required String target,
     @required String description,
     @required Map<String, dynamic> params,
-  }) = _LifeEvent;
-  const LifeEvent._();
+  }) = _LifeEventEntity;
+  const LifeEventEntity._();
 
-  factory LifeEvent.fromJson(Map<String, dynamic> json) => _$LifeEventFromJson(json);
+  factory LifeEventEntity.fromJson(Map<String, dynamic> json) => _$LifeEventEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
-class LifeEventField {
+class LifeEventEntityField {
   /// Event の種別
   static const type = 'type';
 

--- a/lib/api/firestore/life_event_record.dart
+++ b/lib/api/firestore/life_event_record.dart
@@ -8,23 +8,22 @@ import 'life_event.dart';
 part 'life_event_record.freezed.dart';
 part 'life_event_record.g.dart';
 
-/// Document on Firestore
 @freezed
-abstract class LifeEventRecord implements _$LifeEventRecord, Entity {
-  const factory LifeEventRecord({
+abstract class LifeEventRecordEntity implements _$LifeEventRecordEntity, Entity {
+  const factory LifeEventRecordEntity({
     @required String humanId,
-    @required LifeEvent lifeEvent,
+    @required LifeEventEntity lifeEvent,
     @required @TimestampConverter() DateTime createdAt,
-  }) = _LifeEventRecord;
-  const LifeEventRecord._();
+  }) = _LifeEventRecordEntity;
+  const LifeEventRecordEntity._();
 
-  factory LifeEventRecord.fromJson(Map<String, dynamic> json) => _$LifeEventRecordFromJson(json);
+  factory LifeEventRecordEntity.fromJson(Map<String, dynamic> json) => _$LifeEventRecordEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
-class LifeEventRecordField {
+class LifeEventRecordEntityField {
   /// 主(human) の id
   static const humanId = 'humanId';
 

--- a/lib/api/firestore/life_item.dart
+++ b/lib/api/firestore/life_item.dart
@@ -7,25 +7,24 @@ import 'entity.dart';
 part 'life_item.freezed.dart';
 part 'life_item.g.dart';
 
-/// Map Value on Firestore
 @freezed
-abstract class LifeItem implements _$LifeItem, Entity {
-  const factory LifeItem({
+abstract class LifeItemEntity implements _$LifeItemEntity, Entity {
+  const factory LifeItemEntity({
     @required String type,
     @required String key,
     @required int amount,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
-  }) = _LifeItem;
-  const LifeItem._();
+  }) = _LifeItemEntity;
+  const LifeItemEntity._();
 
-  factory LifeItem.fromJson(Map<String, dynamic> json) => _$LifeItemFromJson(json);
+  factory LifeItemEntity.fromJson(Map<String, dynamic> json) => _$LifeItemEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
-class LifeItemField {
+class LifeItemFieldEntity {
   /// Item の種別
   static const type = 'type';
 

--- a/lib/api/firestore/life_road.dart
+++ b/lib/api/firestore/life_road.dart
@@ -10,23 +10,23 @@ part 'life_road.g.dart';
 
 // FIXME: LifeRoad だし、あるべき Field でない
 @freezed
-abstract class HumanLife implements _$HumanLife, Entity {
-  const factory HumanLife({
+abstract class LifeRoadEntity implements _$LifeRoadEntity, Entity {
+  const factory LifeRoadEntity({
     @required @DocumentReferenceConverter() DocumentReference author,
     @required String title,
     @required List<LifeEventEntity> lifeEvents,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
-  }) = _HumanLife;
-  const HumanLife._();
+  }) = _LifeRoadEntity;
+  const LifeRoadEntity._();
 
-  factory HumanLife.fromJson(Map<String, dynamic> json) => _$HumanLifeFromJson(json);
+  factory LifeRoadEntity.fromJson(Map<String, dynamic> json) => _$LifeRoadEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
-class HumanLifeField {
+class LifeRoadEntityField {
   /// 作成者
   static const author = 'author';
 

--- a/lib/api/firestore/life_road.dart
+++ b/lib/api/firestore/life_road.dart
@@ -8,13 +8,13 @@ import 'life_event.dart';
 part 'life_road.freezed.dart';
 part 'life_road.g.dart';
 
-/// Document on Firestore
+// FIXME: LifeRoad だし、あるべき Field でない
 @freezed
 abstract class HumanLife implements _$HumanLife, Entity {
   const factory HumanLife({
     @required @DocumentReferenceConverter() DocumentReference author,
     @required String title,
-    @required List<LifeEvent> lifeEvents,
+    @required List<LifeEventEntity> lifeEvents,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
   }) = _HumanLife;

--- a/lib/api/firestore/life_stage.dart
+++ b/lib/api/firestore/life_stage.dart
@@ -9,22 +9,22 @@ part 'life_stage.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class LifeStage implements _$LifeStage, Entity {
-  const factory LifeStage({
+abstract class LifeStageEntity implements _$LifeStageEntity, Entity {
+  const factory LifeStageEntity({
     @required @DocumentReferenceConverter() DocumentReference human,
     @required String currentLifeStepId,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
-  }) = _LifeStage;
-  const LifeStage._();
+  }) = _LifeStageEntity;
+  const LifeStageEntity._();
 
-  factory LifeStage.fromJson(Map<String, dynamic> json) => _$LifeStageFromJson(json);
+  factory LifeStageEntity.fromJson(Map<String, dynamic> json) => _$LifeStageEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
-class LifeStageField {
+class LifeStageEntityField {
   /// 対象の human
   static const human = 'human';
 

--- a/lib/api/firestore/play_room.dart
+++ b/lib/api/firestore/play_room.dart
@@ -13,8 +13,8 @@ part 'play_room.g.dart';
 /// TODO: announcement はクライアントサイド完結想定だが、必要になったら追加.
 /// TODO: finishedAt は削除ロジックに使う想定だが、不要だったら削除. まだロジックを考え中.
 @freezed
-abstract class PlayRoom implements _$PlayRoom, Entity {
-  const factory PlayRoom({
+abstract class PlayRoomEntity implements _$PlayRoomEntity, Entity {
+  const factory PlayRoomEntity({
     @required @DocumentReferenceConverter() DocumentReference host,
     @required String title,
     @required @DocumentReferenceListConverter() List<DocumentReference> humans,
@@ -23,24 +23,24 @@ abstract class PlayRoom implements _$PlayRoom, Entity {
     @TimestampConverter() DateTime createdAt,
     @TimestampConverter() DateTime updatedAt,
 //    @TimestampConverter() DateTime finishedAt,
-  }) = _PlayRoom;
-  const PlayRoom._();
+  }) = _PlayRoomEntity;
+  const PlayRoomEntity._();
 
-  factory PlayRoom.fromJson(Map<String, dynamic> json) => _$PlayRoomFromJson(json);
+  factory PlayRoomEntity.fromJson(Map<String, dynamic> json) => _$PlayRoomEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 
-  static Document<PlayRoom> decode(DocumentSnapshot snapshot) => Document<PlayRoom>(
+  static Document<PlayRoomEntity> decode(DocumentSnapshot snapshot) => Document<PlayRoomEntity>(
         snapshot.reference,
-        PlayRoom.fromJson(snapshot.data),
+        PlayRoomEntity.fromJson(snapshot.data),
       );
 
   /// humans の document ID List
   List<String> get humanIds => humans.map((human) => human.documentID).toList();
 }
 
-class PlayRoomField {
+class PlayRoomEntityField {
   /// 主催者(user)
   static const host = 'host';
 

--- a/lib/api/firestore/service_control.dart
+++ b/lib/api/firestore/service_control.dart
@@ -9,27 +9,27 @@ part 'service_control.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class ServiceControl implements _$ServiceControl, Entity {
-  const factory ServiceControl({
+abstract class ServiceControlEntity implements _$ServiceControlEntity, Entity {
+  const factory ServiceControlEntity({
     @required bool isMaintenance,
     @required String requiredMinVersion,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
-  }) = _ServiceControl;
-  const ServiceControl._();
+  }) = _ServiceControlEntity;
+  const ServiceControlEntity._();
 
-  factory ServiceControl.fromJson(Map<String, dynamic> json) => _$ServiceControlFromJson(json);
+  factory ServiceControlEntity.fromJson(Map<String, dynamic> json) => _$ServiceControlEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 
-  static Document<ServiceControl> decode(DocumentSnapshot snapshot) => Document<ServiceControl>(
+  static Document<ServiceControlEntity> decode(DocumentSnapshot snapshot) => Document<ServiceControlEntity>(
         snapshot.reference,
-        ServiceControl.fromJson(snapshot.data),
+        ServiceControlEntity.fromJson(snapshot.data),
       );
 }
 
-class ServiceControlField {
+class ServiceControlEntityField {
   /// メンテナス中かどうか
   static const isMaintenance = 'isMaintenance';
 

--- a/lib/api/firestore/store.dart
+++ b/lib/api/firestore/store.dart
@@ -36,21 +36,21 @@ class Store {
 
   // 関連: https://stackoverflow.com/a/55237197/10928938
   Document<T> _decode<T extends Entity>(DocumentSnapshot snapshot) {
-    if (T == ServiceControl) return ServiceControl.decode(snapshot) as Document<T>;
-    if (T == PlayRoom) return PlayRoom.decode(snapshot) as Document<T>;
+    if (T == ServiceControlEntity) return ServiceControlEntity.decode(snapshot) as Document<T>;
+    if (T == PlayRoomEntity) return PlayRoomEntity.decode(snapshot) as Document<T>;
     throw Error(); // unexpected
   }
 
   @visibleForTesting
   String getCollectionId<T>() {
-    if (T == ServiceControl) return 'serviceControl';
-    if (T == LifeEvent) return 'lifeEvent';
-    if (T == LifeEventRecord) return 'lifeEventRecord';
-    if (T == LifeItem) return 'lifeItem';
+    if (T == ServiceControlEntity) return 'serviceControl';
+    if (T == LifeEventEntity) return 'lifeEvent';
+    if (T == LifeEventRecordEntity) return 'lifeEventRecord';
+    if (T == LifeItemEntity) return 'lifeItem';
     if (T == HumanLife) return 'humanLife';
-    if (T == LifeStage) return 'LifeStage';
-    if (T == PlayRoom) return 'playRoom';
-    if (T == User) return 'user';
+    if (T == LifeStageEntity) return 'LifeStage';
+    if (T == PlayRoomEntity) return 'playRoom';
+    if (T == UserEntity) return 'user';
     throw Error(); // unexpected
   }
 }

--- a/lib/api/firestore/store.dart
+++ b/lib/api/firestore/store.dart
@@ -47,7 +47,7 @@ class Store {
     if (T == LifeEventEntity) return 'lifeEvent';
     if (T == LifeEventRecordEntity) return 'lifeEventRecord';
     if (T == LifeItemEntity) return 'lifeItem';
-    if (T == HumanLife) return 'humanLife';
+    if (T == LifeRoadEntity) return 'lifeRoad';
     if (T == LifeStageEntity) return 'LifeStage';
     if (T == PlayRoomEntity) return 'playRoom';
     if (T == UserEntity) return 'user';

--- a/lib/api/firestore/user.dart
+++ b/lib/api/firestore/user.dart
@@ -13,9 +13,9 @@ abstract class UserEntity implements _$UserEntity, Entity {
   const factory UserEntity({
     @required String uid,
     @required String displayName,
-    @required @DocumentReferenceConverter() DocumentReference joinPlayRoom,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
+    @DocumentReferenceConverter() DocumentReference joinPlayRoom,
   }) = _UserEntity;
   const UserEntity._();
 

--- a/lib/api/firestore/user.dart
+++ b/lib/api/firestore/user.dart
@@ -9,23 +9,23 @@ part 'user.g.dart';
 
 /// Document on Firestore
 @freezed
-abstract class User implements _$User, Entity {
-  const factory User({
+abstract class UserEntity implements _$UserEntity, Entity {
+  const factory UserEntity({
     @required String uid,
     @required String displayName,
     @required @DocumentReferenceConverter() DocumentReference joinPlayRoom,
     @required @TimestampConverter() DateTime createdAt,
     @required @TimestampConverter() DateTime updatedAt,
-  }) = _User;
-  const User._();
+  }) = _UserEntity;
+  const UserEntity._();
 
-  factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+  factory UserEntity.fromJson(Map<String, dynamic> json) => _$UserEntityFromJson(json);
 
   @override
   Map<String, dynamic> encode() => replacingTimestamp(json: toJson());
 }
 
-class UserField {
+class UserEntityField {
   /// uid (by Auth)
   static const uid = 'uid';
 

--- a/lib/human_life_game_app.dart
+++ b/lib/human_life_game_app.dart
@@ -17,7 +17,7 @@ class HumanLifeGameApp extends StatelessWidget {
   static Widget inProviders({Key key, Auth auth, Dice dice, Store store}) => MultiProvider(
         key: key,
         providers: [
-          Provider(create: (_) => Router()),
+          Provider(create: (_) => const Router()),
           Provider(create: (_) => auth ?? const Auth()),
           Provider(create: (_) => store ?? Store(Firestore.instance)),
           Provider(create: (_) => dice ?? const Dice()),

--- a/lib/i18n/extensions/i18n_lobby.dart
+++ b/lib/i18n/extensions/i18n_lobby.dart
@@ -9,4 +9,9 @@ extension I18nLobby on I18n {
         name: 'lobbyCreatePublicRoomButtonTooltip',
         locale: localeName,
       );
+  String get lobbyEnterTheRoomButtonText => Intl.message(
+        'enter the room',
+        name: 'lobbyEnterTheRoomButtonText',
+        locale: localeName,
+      );
 }

--- a/lib/i18n/intl_en.arb
+++ b/lib/i18n/intl_en.arb
@@ -17,6 +17,11 @@
     "type": "text",
     "placeholders": {}
   },
+  "lobbyEnterTheRoomButtonText": "enter the room",
+  "@lobbyEnterTheRoomButtonText": {
+    "type": "text",
+    "placeholders": {}
+  },
   "rollDice": "Roll the dice",
   "@rollDice": {
     "type": "text",

--- a/lib/i18n/intl_ja.arb
+++ b/lib/i18n/intl_ja.arb
@@ -17,6 +17,11 @@
     "type": "text",
     "placeholders": {}
   },
+  "lobbyEnterTheRoomButtonText": "部屋に入る",
+  "@lobbyEnterTheRoomButtonText": {
+    "type": "text",
+    "placeholders": {}
+  },
   "rollDice": "サイコロを振る",
   "@rollDice": {
     "type": "text",

--- a/lib/i18n/intl_messages.arb
+++ b/lib/i18n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-06-21T23:22:55.697804",
+  "@@last_modified": "2020-06-26T21:21:07.903910",
   "appTitle": "Human Life Game",
   "@appTitle": {
     "type": "text",
@@ -14,6 +14,11 @@
   },
   "lobbyCreatePublicRoomButtonTooltip": "create public room",
   "@lobbyCreatePublicRoomButtonTooltip": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "lobbyEnterTheRoomButtonText": "enter the room",
+  "@lobbyEnterTheRoomButtonText": {
     "type": "text",
     "placeholders": {}
   },

--- a/lib/i18n/messages_en.dart
+++ b/lib/i18n/messages_en.dart
@@ -37,6 +37,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "lifeEventRecordsText": MessageLookupByLibrary.simpleMessage("Reserved area:lifeEventRecords"),
         "lifeStepEventType": m0,
         "lobbyCreatePublicRoomButtonTooltip": MessageLookupByLibrary.simpleMessage("create public room"),
+        "lobbyEnterTheRoomButtonText": MessageLookupByLibrary.simpleMessage("enter the room"),
         "playerActionNo": MessageLookupByLibrary.simpleMessage("NO"),
         "playerActionYes": MessageLookupByLibrary.simpleMessage("YES"),
         "resultAnnouncementDialogMessage": MessageLookupByLibrary.simpleMessage("Result Announcement !!"),

--- a/lib/i18n/messages_ja.dart
+++ b/lib/i18n/messages_ja.dart
@@ -37,6 +37,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "lifeEventRecordsText": MessageLookupByLibrary.simpleMessage("予約領域:lifeEventRecords"),
         "lifeStepEventType": m0,
         "lobbyCreatePublicRoomButtonTooltip": MessageLookupByLibrary.simpleMessage("部屋を作る"),
+        "lobbyEnterTheRoomButtonText": MessageLookupByLibrary.simpleMessage("部屋に入る"),
         "playerActionNo": MessageLookupByLibrary.simpleMessage("いいえ"),
         "playerActionYes": MessageLookupByLibrary.simpleMessage("はい"),
         "resultAnnouncementDialogMessage": MessageLookupByLibrary.simpleMessage("結果発表 ！！"),

--- a/lib/i18n/messages_messages.dart
+++ b/lib/i18n/messages_messages.dart
@@ -37,6 +37,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "lifeEventRecordsText": MessageLookupByLibrary.simpleMessage("Reserved area:lifeEventRecords"),
         "lifeStepEventType": m0,
         "lobbyCreatePublicRoomButtonTooltip": MessageLookupByLibrary.simpleMessage("create public room"),
+        "lobbyEnterTheRoomButtonText": MessageLookupByLibrary.simpleMessage("enter the room"),
         "playerActionNo": MessageLookupByLibrary.simpleMessage("NO"),
         "playerActionYes": MessageLookupByLibrary.simpleMessage("YES"),
         "resultAnnouncementDialogMessage": MessageLookupByLibrary.simpleMessage("Result Announcement !!"),

--- a/lib/models/lobby/lobby_notifier.dart
+++ b/lib/models/lobby/lobby_notifier.dart
@@ -33,8 +33,8 @@ class LobbyNotifier extends ValueNotifier<LobbyState> {
 
   Future<void> createPublicPlayRoom() async {
     final user = await _auth.currentUser;
-    final userDocRef = _store.docRef<User>(user.id);
-    final room = PlayRoom(
+    final userDocRef = _store.docRef<UserEntity>(user.id);
+    final room = PlayRoomEntity(
       host: userDocRef.ref,
       title: 'はじめての人生',
       humans: [userDocRef.ref],
@@ -43,25 +43,25 @@ class LobbyNotifier extends ValueNotifier<LobbyState> {
       lifeRoad: userDocRef.ref,
       currentTurnHumanId: user.id,
     );
-    final roomDocRef = _store.collectionRef<PlayRoom>().docRef();
+    final roomDocRef = _store.collectionRef<PlayRoomEntity>().docRef();
     final batch = _store.firestore.batch();
     await roomDocRef.setData(room.encode(), batch: batch);
     await userDocRef.updateData(
       <String, dynamic>{
-        UserField.joinPlayRoom: roomDocRef.ref,
+        UserEntityField.joinPlayRoom: roomDocRef.ref,
         TimestampField.updatedAt: FieldValue.serverTimestamp(),
       },
       batch: batch,
     );
     await batch.commit(); // FIXME: エラーハンドリング. 特に既に join 済みの場合のハンドリング.
     value.navigateArgumentsToPlayRoom = PlayRoomNotifierArguments(
-      Document<PlayRoom>(roomDocRef.ref, room),
+      Document<PlayRoomEntity>(roomDocRef.ref, room),
     );
     notifyListeners();
   }
 
   Future<void> fetchPlayRooms() async {
-    final collectionRef = _store.collectionRef<PlayRoom>();
+    final collectionRef = _store.collectionRef<PlayRoomEntity>();
     value.publicPlayRooms = await collectionRef.getDocuments(
       (query) => query.limit(_roomListLimit).orderBy(TimestampField.createdAt),
     );

--- a/lib/models/lobby/lobby_notifier.dart
+++ b/lib/models/lobby/lobby_notifier.dart
@@ -9,8 +9,7 @@ import 'lobby_state.dart';
 
 class LobbyNotifier extends ValueNotifier<LobbyState> {
   LobbyNotifier(this._auth, this._store) : super(LobbyState()) {
-    // 初期取得
-    fetchPlayRooms();
+    fetchPlayRooms(); // 非同期で初期取得
   }
 
   final Auth _auth;

--- a/lib/models/lobby/lobby_state.dart
+++ b/lib/models/lobby/lobby_state.dart
@@ -6,7 +6,7 @@ import '../play_room/play_room_notifier.dart';
 class LobbyState {
   LobbyState();
 
-  List<Document<PlayRoom>> publicPlayRooms = [];
+  List<Document<PlayRoomEntity>> publicPlayRooms = [];
 
   PlayRoomNotifierArguments navigateArgumentsToPlayRoom;
 }

--- a/lib/models/lobby/lobby_state.dart
+++ b/lib/models/lobby/lobby_state.dart
@@ -1,9 +1,12 @@
 import 'package:firestore_ref/firestore_ref.dart';
 
 import '../../api/firestore/play_room.dart';
+import '../play_room/play_room_notifier.dart';
 
 class LobbyState {
   LobbyState();
 
   List<Document<PlayRoom>> publicPlayRooms = [];
+
+  PlayRoomNotifierArguments navigateArgumentsToPlayRoom;
 }

--- a/lib/models/play_room/play_room_notifier.dart
+++ b/lib/models/play_room/play_room_notifier.dart
@@ -1,6 +1,8 @@
+import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../api/dice.dart';
+import '../../api/firestore/play_room.dart';
 import '../../i18n/i18n.dart';
 import '../../services/life_event_service.dart';
 import '../common/human.dart';
@@ -9,6 +11,12 @@ import '../common/life_step.dart';
 import 'life_event_record.dart';
 import 'life_stage.dart';
 import 'play_room_state.dart';
+
+@immutable
+class PlayRoomNotifierArguments {
+  const PlayRoomNotifierArguments(this.playRoom);
+  final Document<PlayRoom> playRoom;
+}
 
 /// NOTE: 以下の点を把握した上で状態管理を実装すること.
 ///

--- a/lib/models/play_room/play_room_notifier.dart
+++ b/lib/models/play_room/play_room_notifier.dart
@@ -15,7 +15,7 @@ import 'play_room_state.dart';
 @immutable
 class PlayRoomNotifierArguments {
   const PlayRoomNotifierArguments(this.playRoom);
-  final Document<PlayRoom> playRoom;
+  final Document<PlayRoomEntity> playRoom;
 }
 
 /// NOTE: 以下の点を把握した上で状態管理を実装すること.

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -15,10 +15,12 @@ import 'screens/sign_in/sign_in.dart';
 
 @immutable
 class Router {
-  final String lobby = '/lobby';
-  final String signIn = '/sign_in';
-  final String playRoom = '/play_room';
-  final String maintenance = '/maintenance';
+  const Router();
+
+  String get lobby => '/lobby';
+  String get signIn => '/sign_in';
+  String get playRoom => '/play_room';
+  String get maintenance => '/maintenance';
 
   Route<dynamic> generateRoutes(RouteSettings settings) {
     final name = settings.name;

--- a/lib/screens/lobby/room_list_item.dart
+++ b/lib/screens/lobby/room_list_item.dart
@@ -56,13 +56,10 @@ class RoomListItem extends StatelessWidget {
   SizedBox _joinButton(BuildContext context) => SizedBox(
         width: 420,
         height: 40,
-        child: Tooltip(
-          message: 'enter the room',
-          child: FlatButton(
-            color: Colors.lightBlue,
-            onPressed: () => Navigator.of(context).pushNamed(context.read<Router>().playRoom),
-            child: const Text('enter the room'),
-          ),
+        child: FlatButton(
+          color: Colors.lightBlue,
+          onPressed: () => Navigator.of(context).pushNamed(context.read<Router>().playRoom),
+          child: const Text('enter the room'),
         ),
       );
 }

--- a/lib/screens/lobby/room_list_item.dart
+++ b/lib/screens/lobby/room_list_item.dart
@@ -8,7 +8,7 @@ import '../../router.dart';
 class RoomListItem extends StatelessWidget {
   const RoomListItem(this._playRoom, {Key key}) : super(key: key);
 
-  final Document<PlayRoom> _playRoom;
+  final Document<PlayRoomEntity> _playRoom;
 
   @override
   Widget build(BuildContext context) => Column(

--- a/lib/screens/lobby/room_list_item.dart
+++ b/lib/screens/lobby/room_list_item.dart
@@ -56,10 +56,13 @@ class RoomListItem extends StatelessWidget {
   SizedBox _joinButton(BuildContext context) => SizedBox(
         width: 420,
         height: 40,
-        child: FlatButton(
-          color: Colors.lightBlue,
-          onPressed: () => Navigator.of(context).pushNamed(context.read<Router>().playRoom),
-          child: const Text('Join a Game'),
+        child: Tooltip(
+          message: 'enter the room',
+          child: FlatButton(
+            color: Colors.lightBlue,
+            onPressed: () => Navigator.of(context).pushNamed(context.read<Router>().playRoom),
+            child: const Text('enter the room'),
+          ),
         ),
       );
 }

--- a/lib/screens/lobby/room_list_item.dart
+++ b/lib/screens/lobby/room_list_item.dart
@@ -1,3 +1,4 @@
+import 'package:HumanLifeGame/i18n/i18n.dart';
 import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -59,7 +60,7 @@ class RoomListItem extends StatelessWidget {
         child: FlatButton(
           color: Colors.lightBlue,
           onPressed: () => Navigator.of(context).pushNamed(context.read<Router>().playRoom),
-          child: const Text('enter the room'),
+          child: Text(I18n.of(context).lobbyEnterTheRoomButtonText),
         ),
       );
 }

--- a/lib/screens/lobby/room_list_item.dart
+++ b/lib/screens/lobby/room_list_item.dart
@@ -1,9 +1,9 @@
-import 'package:HumanLifeGame/i18n/i18n.dart';
 import 'package:firestore_ref/firestore_ref.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../api/firestore/play_room.dart';
+import '../../i18n/i18n.dart';
 import '../../router.dart';
 
 class RoomListItem extends StatelessWidget {

--- a/lib/screens/maintenance/maintenance.dart
+++ b/lib/screens/maintenance/maintenance.dart
@@ -13,8 +13,8 @@ class Maintenance extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
         body: Center(
-          child: StreamBuilder<Document<ServiceControl>>(
-            stream: context.watch<Store>().docRef<ServiceControl>(ServiceControlDocId.web).document(),
+          child: StreamBuilder<Document<ServiceControlEntity>>(
+            stream: context.watch<Store>().docRef<ServiceControlEntity>(ServiceControlDocId.web).document(),
             builder: (context, snap) {
               if (!snap.hasData) return const Text('no data');
               return snap.data.entity.isMaintenance

--- a/test/widget/helper/widget_build_helper.dart
+++ b/test/widget/helper/widget_build_helper.dart
@@ -15,7 +15,7 @@ Widget testableApp({
   List<Provider> providers,
 }) {
   final defaultProviders = [
-    Provider(create: (_) => Router()),
+    Provider(create: (_) => const Router()),
     Provider(create: (_) => const Auth()),
     Provider(create: (_) => Store(MockFirestoreInstance())),
     Provider(create: (_) => const Dice()),

--- a/test/widget/helper/widget_build_helper.dart
+++ b/test/widget/helper/widget_build_helper.dart
@@ -1,33 +1,45 @@
-library widget_buuild_helper;
-
+import 'package:HumanLifeGame/api/auth.dart';
+import 'package:HumanLifeGame/api/dice.dart';
+import 'package:HumanLifeGame/api/firestore/store.dart';
 import 'package:HumanLifeGame/i18n/i18n.dart';
 import 'package:HumanLifeGame/i18n/i18n_delegate.dart';
 import 'package:HumanLifeGame/router.dart';
+import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
-Widget testableApp({@required Widget home, Locale locale = const Locale('en', 'US')}) => MultiProvider(
-      providers: [
-        Provider(create: (context) => Router()),
-      ],
-      child: Consumer<Router>(
-        builder: (_, router, __) => MaterialApp(
-          onGenerateTitle: (context) => I18n.of(context).appTitle,
-          localizationsDelegates: const [
-            I18nDelegate(),
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: const [Locale('en', 'US'), Locale('ja', 'JP')],
-          locale: locale,
-          theme: ThemeData(
-            primarySwatch: Colors.blue,
-            visualDensity: VisualDensity.adaptivePlatformDensity,
-          ),
-          home: home,
-          onGenerateRoute: router.generateRoutes,
+Widget testableApp({
+  @required Widget home,
+  Locale locale = const Locale('en', 'US'),
+  List<Provider> providers,
+}) {
+  final defaultProviders = [
+    Provider(create: (_) => Router()),
+    Provider(create: (_) => const Auth()),
+    Provider(create: (_) => Store(MockFirestoreInstance())),
+    Provider(create: (_) => const Dice()),
+  ];
+  return MultiProvider(
+    providers: providers ?? defaultProviders,
+    child: Builder(
+      builder: (context) => MaterialApp(
+        onGenerateTitle: (context) => I18n.of(context).appTitle,
+        localizationsDelegates: const [
+          I18nDelegate(),
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', 'US'), Locale('ja', 'JP')],
+        locale: locale,
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
+        home: home,
+        onGenerateRoute: context.watch<Router>().generateRoutes,
       ),
-    );
+    ),
+  );
+}

--- a/test/widget/life_step_test.dart
+++ b/test/widget/life_step_test.dart
@@ -23,10 +23,9 @@ Future<void> main() async {
     await tester.pump();
 
     expect(
-        find.byWidgetPredicate(
-          (widget) => widget is Card && widget.color == LifeStep.positive,
-        ),
-        findsOneWidget);
+      find.byWidgetPredicate((widget) => widget is Card && widget.color == LifeStep.positive),
+      findsOneWidget,
+    );
   });
 
   testWidgets('show Card with negative Color', (tester) async {
@@ -42,10 +41,9 @@ Future<void> main() async {
     await tester.pump();
 
     expect(
-        find.byWidgetPredicate(
-          (widget) => widget is Card && widget.color == LifeStep.negative,
-        ),
-        findsOneWidget);
+      find.byWidgetPredicate((widget) => widget is Card && widget.color == LifeStep.negative),
+      findsOneWidget,
+    );
   });
 
   testWidgets('show Card with normal Color', (tester) async {
@@ -61,10 +59,9 @@ Future<void> main() async {
     await tester.pump();
 
     expect(
-        find.byWidgetPredicate(
-          (widget) => widget is Card && widget.color == LifeStep.normal,
-        ),
-        findsOneWidget);
+      find.byWidgetPredicate((widget) => widget is Card && widget.color == LifeStep.normal),
+      findsOneWidget,
+    );
   });
 
   testWidgets('show description', (tester) async {

--- a/test/widget/lobby_test.dart
+++ b/test/widget/lobby_test.dart
@@ -69,16 +69,17 @@ Future<void> main() async {
     when(auth.currentUser).thenAnswer((_) async => user);
     final firestore = MockFirestoreInstance();
     final store = Store(firestore);
-    // TODO: ダミーデータを投入
-    const uid = 'foo';
-    final userDocRef = store.docRef<UserEntity>(uid);
+
+    // ダミー user を投入
+    final userDocRef = store.docRef<UserEntity>(user.id);
     await userDocRef.set(UserEntity(
-      uid: uid,
-      displayName: 'widget test man',
+      uid: user.id,
+      displayName: user.name,
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ));
 
+    // ダミー room を投入
     // FIXME: 本当は add で書くべきだが、https://github.com/atn832/cloud_firestore_mocks/pull/99 のバグがあるので set で書いてる
     const roomNum = 2;
     for (var i = 0; i < roomNum; ++i) {
@@ -88,7 +89,7 @@ Future<void> main() async {
           humans: [userDocRef.ref],
           title: randString,
           lifeRoad: store.docRef<LifeRoadEntity>(randString).ref,
-          currentTurnHumanId: uid));
+          currentTurnHumanId: user.id));
     }
 
     await tester.pumpWidget(
@@ -106,7 +107,7 @@ Future<void> main() async {
     await tester.pump();
     expect(find.byType(HumanLifeTips), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsOneWidget);
-    expect(find.byType(RoomListItem), findsNWidgets(roomNum)); // ダミーデータの数だけ表示されてる
+    expect(find.byType(RoomListItem), findsNWidgets(roomNum)); // ダミーデータの数だけ表示される
 
     // 複数ある enter button のうち１つをタップする
     await tester.tap(find.text(i18n.lobbyEnterTheRoomButtonText).first);

--- a/test/widget/lobby_test.dart
+++ b/test/widget/lobby_test.dart
@@ -1,6 +1,9 @@
 import 'package:HumanLifeGame/api/auth.dart';
 import 'package:HumanLifeGame/api/dice.dart';
+import 'package:HumanLifeGame/api/firestore/life_road.dart';
+import 'package:HumanLifeGame/api/firestore/play_room.dart';
 import 'package:HumanLifeGame/api/firestore/store.dart';
+import 'package:HumanLifeGame/api/firestore/user.dart';
 import 'package:HumanLifeGame/i18n/i18n.dart';
 import 'package:HumanLifeGame/models/common/user.dart';
 import 'package:HumanLifeGame/router.dart';
@@ -65,6 +68,26 @@ Future<void> main() async {
     final firestore = MockFirestoreInstance();
     final store = Store(firestore);
     // TODO: ダミーデータを投入
+    const uid = 'foo';
+    final userDocRef = store.docRef<UserEntity>(uid);
+    await userDocRef.set(UserEntity(
+      uid: uid,
+      displayName: 'widget test man',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ));
+    final playRoom = await store.collectionRef<PlayRoomEntity>().add(PlayRoomEntity(
+        host: userDocRef.ref,
+        humans: [userDocRef.ref],
+        title: 'bar',
+        lifeRoad: store.docRef<LifeRoadEntity>('aaa').ref,
+        currentTurnHumanId: uid));
+    final playRoom2 = await store.collectionRef<PlayRoomEntity>().add(PlayRoomEntity(
+        host: userDocRef.ref,
+        humans: [userDocRef.ref],
+        title: 'bar2',
+        lifeRoad: store.docRef<LifeRoadEntity>('bbb').ref,
+        currentTurnHumanId: uid));
 
     await tester.pumpWidget(
       testableApp(
@@ -81,7 +104,7 @@ Future<void> main() async {
     await tester.pump();
     expect(find.byType(HumanLifeTips), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsOneWidget);
-    expect(find.byType(RoomListItem), findsNWidgets(12345)); // ダミーデータの数だけ表示されてる
+    expect(find.byType(RoomListItem), findsNWidgets(2)); // ダミーデータの数だけ表示されてる
 
     // TODO: join
 

--- a/test/widget/lobby_test.dart
+++ b/test/widget/lobby_test.dart
@@ -108,8 +108,10 @@ Future<void> main() async {
     expect(find.byType(FloatingActionButton), findsOneWidget);
     expect(find.byType(RoomListItem), findsNWidgets(roomNum)); // ダミーデータの数だけ表示されてる
 
-    // TODO: join
-
-    // TODO: playRoom に遷移
+    // 複数ある enter button のうち１つをタップする
+    await tester.tap(find.text(i18n.lobbyEnterTheRoomButtonText).first);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(PlayRoom), findsOneWidget); // playRoom に遷移
   });
 }

--- a/test/widget/lobby_test.dart
+++ b/test/widget/lobby_test.dart
@@ -35,7 +35,7 @@ Future<void> main() async {
     await tester.pumpWidget(
       testableApp(
         providers: [
-          Provider<Router>(create: (_) => Router()),
+          Provider<Router>(create: (_) => const Router()),
           Provider<Dice>(create: (_) => const Dice()),
           Provider<Auth>(create: (_) => auth),
           Provider<Store>(create: (_) => store),
@@ -56,5 +56,35 @@ Future<void> main() async {
     await tester.pump();
     await tester.pump();
     expect(find.byType(PlayRoom), findsOneWidget); // playRoom に遷移する
+  });
+
+  testWidgets('list public play rooms', (tester) async {
+    final user = UserModel(id: '123', name: 'foo', isAnonymous: true);
+    final auth = MockAuth();
+    when(auth.currentUser).thenAnswer((_) async => user);
+    final firestore = MockFirestoreInstance();
+    final store = Store(firestore);
+    // TODO: ダミーデータを投入
+
+    await tester.pumpWidget(
+      testableApp(
+        providers: [
+          Provider<Router>(create: (_) => const Router()),
+          Provider<Dice>(create: (_) => const Dice()),
+          Provider<Auth>(create: (_) => auth),
+          Provider<Store>(create: (_) => store),
+        ],
+        home: Lobby.inProviders(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(HumanLifeTips), findsOneWidget);
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+    expect(find.byType(RoomListItem), findsNWidgets(12345)); // ダミーデータの数だけ表示されてる
+
+    // TODO: join
+
+    // TODO: playRoom に遷移
   });
 }

--- a/test/widget/lobby_test.dart
+++ b/test/widget/lobby_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:HumanLifeGame/api/auth.dart';
 import 'package:HumanLifeGame/api/dice.dart';
 import 'package:HumanLifeGame/api/firestore/life_road.dart';
@@ -76,18 +78,18 @@ Future<void> main() async {
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ));
-    final playRoom = await store.collectionRef<PlayRoomEntity>().add(PlayRoomEntity(
-        host: userDocRef.ref,
-        humans: [userDocRef.ref],
-        title: 'bar',
-        lifeRoad: store.docRef<LifeRoadEntity>('aaa').ref,
-        currentTurnHumanId: uid));
-    final playRoom2 = await store.collectionRef<PlayRoomEntity>().add(PlayRoomEntity(
-        host: userDocRef.ref,
-        humans: [userDocRef.ref],
-        title: 'bar2',
-        lifeRoad: store.docRef<LifeRoadEntity>('bbb').ref,
-        currentTurnHumanId: uid));
+
+    // FIXME: 本当は add で書くべきだが、https://github.com/atn832/cloud_firestore_mocks/pull/99 のバグがあるので set で書いてる
+    const roomNum = 2;
+    for (var i = 0; i < roomNum; ++i) {
+      final randString = Random().nextInt(1000).toString();
+      await store.collectionRef<PlayRoomEntity>().docRef().set(PlayRoomEntity(
+          host: userDocRef.ref,
+          humans: [userDocRef.ref],
+          title: randString,
+          lifeRoad: store.docRef<LifeRoadEntity>(randString).ref,
+          currentTurnHumanId: uid));
+    }
 
     await tester.pumpWidget(
       testableApp(
@@ -104,7 +106,7 @@ Future<void> main() async {
     await tester.pump();
     expect(find.byType(HumanLifeTips), findsOneWidget);
     expect(find.byType(FloatingActionButton), findsOneWidget);
-    expect(find.byType(RoomListItem), findsNWidgets(2)); // ダミーデータの数だけ表示されてる
+    expect(find.byType(RoomListItem), findsNWidgets(roomNum)); // ダミーデータの数だけ表示されてる
 
     // TODO: join
 

--- a/test/widget/maintenance_test.dart
+++ b/test/widget/maintenance_test.dart
@@ -10,15 +10,15 @@ import 'package:provider/provider.dart';
 void main() {
   testWidgets('not under maintenance', (tester) async {
     final serviceControlData = {
-      ServiceControlField.isMaintenance: false,
-      ServiceControlField.requiredMinVersion: 'X.Y.Z',
+      ServiceControlEntityField.isMaintenance: false,
+      ServiceControlEntityField.requiredMinVersion: 'X.Y.Z',
       TimestampField.createdAt: DateTime.now(),
       TimestampField.updatedAt: DateTime.now(),
     };
     final firestore = MockFirestoreInstance();
     final store = Store(firestore);
     await firestore
-        .collection(store.getCollectionId<ServiceControl>())
+        .collection(store.getCollectionId<ServiceControlEntity>())
         .document(ServiceControlDocId.web)
         .setData(serviceControlData);
 
@@ -35,15 +35,15 @@ void main() {
 
   testWidgets('under maintenance', (tester) async {
     final serviceControlData = {
-      ServiceControlField.isMaintenance: true,
-      ServiceControlField.requiredMinVersion: 'X.Y.Z',
+      ServiceControlEntityField.isMaintenance: true,
+      ServiceControlEntityField.requiredMinVersion: 'X.Y.Z',
       TimestampField.createdAt: DateTime.now(),
       TimestampField.updatedAt: DateTime.now(),
     };
     final firestore = MockFirestoreInstance();
     final store = Store(firestore);
     await firestore
-        .collection(store.getCollectionId<ServiceControl>())
+        .collection(store.getCollectionId<ServiceControlEntity>())
         .document(ServiceControlDocId.web)
         .setData(serviceControlData);
 


### PR DESCRIPTION
## Overview

以下2パターンについて、playRoom への遷移を実装する。

* playRoom 作成時
* join

また、Entity の命名修正しなきゃいけなくなったのでそれも一緒にやっちゃてる。

## Reference
* **https://flutter.dev/docs/cookbook/navigation/navigate-with-arguments**