### PR TITLE
mild fix jobs

### DIFF
--- a/.github/workflows/dart_format.yaml
+++ b/.github/workflows/dart_format.yaml
@@ -14,8 +14,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_analyzer.yaml
+++ b/.github/workflows/flutter_analyzer.yaml
@@ -13,8 +13,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -10,8 +10,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_test.yaml
+++ b/.github/workflows/flutter_test.yaml
@@ -13,8 +13,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/flutter_web_deploy.yaml
+++ b/.github/workflows/flutter_web_deploy.yaml
@@ -11,8 +11,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/update_firebase_js_sdk.yaml
+++ b/.github/workflows/update_firebase_js_sdk.yaml
@@ -10,9 +10,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          ref: master
       - name: fetch latest version
         run: echo "::set-env name=LATEST_VERSION::$(npm show firebase version)"
       - uses: sensuikan1973/replace-deps@v1

--- a/.github/workflows/update_flutter_dependencies.yaml
+++ b/.github/workflows/update_flutter_dependencies.yaml
@@ -10,9 +10,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          ref: master
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'

--- a/.github/workflows/upload_dart_docs.yaml
+++ b/.github/workflows/upload_dart_docs.yaml
@@ -11,8 +11,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'


### PR DESCRIPTION
See: https://github.com/actions/checkout#usage

* `fetch-depth`
> \# Number of commits to fetch. 0 indicates all history.
> \# Default: 1
> fetch-depth: ''


* `ref`
>  \# The branch, tag or SHA to checkout. When checking out the repository that
>  \# triggered a workflow, this defaults to the reference or SHA for that event.
>  \# Otherwise, uses the default branch.
>  ref: ''
