### PR TITLE
fix firebase analytics init

### DIFF
--- a/web/init_firebase.js
+++ b/web/init_firebase.js
@@ -10,13 +10,14 @@ if(window.location.hostname === 'localhost'){
      measurementId: "G-P10ZHWT57Q"
   };
   firebase.initializeApp(firebaseConfig);
+  firebase.analytics();
 } else {
   fetch("/__/firebase/init.json").then( res => res.json() ).then( json => {
    firebase.initializeApp(json);
+   firebase.analytics();
   });
 }
 
-firebase.analytics();
 // See: https://firebase.google.com/docs/auth/web/auth-state-persistence
 // See: https://github.com/FirebaseExtended/flutterfire/issues/1714
 // firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL);


### PR DESCRIPTION
この件の対応 (https://done-sensuikan1973.slack.com/archives/CFC2A9URW/p1596467390354700)

```sh
Uncaught FirebaseError: Firebase: No Firebase App '[DEFAULT]' has been created - call Firebase App.initializeApp() (app/no-app).
    at f (https://www.gstatic.com/firebasejs/7.17.1/firebase-app.js:1:16815)
    at Object.i [as analytics] (https://www.gstatic.com/firebasejs/7.17.1/firebase-app.js:1:17072)
    at https://human-life-game-dev.web.app/init_firebase.js:19:10
contentscript.js:1 LGTM Registering listener in contentscript...
contentscript.js:1 ... Done registering contentscript.
2zone.dart:1175 Uncaught FirebaseError: Missing or insufficient permissions. (permission-denied)
    at Object.c (https://human-life-game-dev.web.app/main.dart.js:2264:3)
    at https://human-life-game-dev.web.app/main.dart.js:10190:24
    at abH.a (https://human-life-game-dev.web.app/main.dart.js:3710:71)
    at abH.$2 (https://human-life-game-dev.web.app/main.dart.js:25850:23)
    at ab0.$2 (https://human-life-game-dev.web.app/main.dart.js:25845:25)
    at P4.yr (https://human-life-game-dev.web.app/main.dart.js:26765:43)
    at P4.yq (https://human-life-game-dev.web.app/main.dart.js:26767:32)
    at n4.YR (https://human-life-game-dev.web.app/main.dart.js:26081:23)
    at a7f.$0 (https://human-life-game-dev.web.app/main.dart.js:26232:37)
    at Object.qo (https://human-life-game-dev.web.app/main.dart.js:3828:78)
```

呼び出しタイミングが不適切で、initializeApp の完了前に呼ばれることがあった。
