### PR TITLE
update_flutter_dependencies workflow がコケまくってる件の対応

### DIFF
--- a/.github/workflows/update_flutter_dependencies.yaml
+++ b/.github/workflows/update_flutter_dependencies.yaml
@@ -13,6 +13,9 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'beta'
+          
+      - name: Workaround for https://github.com/subosito/flutter-action/issues/39
+        run: flutter channel beta && flutter upgrade
 
         # See: https://pub.dev/packages/pubspec_update
         # 公式で yarn upgrade --latest 相当のことができるコマンドが用意されてないので、サードパーティの package を使う


### PR DESCRIPTION
flutter sdk の version 解決がうまくいってないやつ。
他の workflow でやってるように workaround を入れておく